### PR TITLE
EZP-23717: Implemented YooChoose client

### DIFF
--- a/Client/RecommendationClient.php
+++ b/Client/RecommendationClient.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributd with this source code.
+ */
+namespace EzSystems\RecommendationBundle\Client;
+
+interface RecommendationClient
+{
+    public function updateContent($contentId);
+
+    public function deleteContent($contentId);
+}

--- a/Client/YooChooseNotifier.php
+++ b/Client/YooChooseNotifier.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributd with this source code.
+ */
+namespace EzSystems\RecommendationBundle\Client;
+
+use GuzzleHttp\ClientInterface as GuzzleClient;
+use InvalidArgumentException;
+use RuntimeException;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * A recommendation client that sends notifications to a YooChoose server.
+ */
+class YooChooseNotifier implements RecommendationClient
+{
+    /** @var string */
+    protected $options;
+
+    /** @var \GuzzleHttp\ClientInterface */
+    private $guzzle;
+
+    /**
+     * Constructs a YooChooseNotifier Recommendation Client.
+     *
+     * @param array $options
+     *        Keys (all required):
+     *        - customer-id: the yoochoose customer ID, e.g. 12345
+     *        - license-key: yoochoose license key, e.g. 1234-5678-9012-3456-7890
+     *        - api-endpoint: yoochoose http api endpoint
+     *        - base-uri: the site's REST API base URI (without the prefix)
+     * @param \GuzzleHttp\ClientInterface $guzzle
+     */
+    public function __construct( array $options, GuzzleClient $guzzle )
+    {
+        $resolver = new OptionsResolver();
+        $this->configureOptions( $resolver );
+
+        $this->options = $resolver->resolve( $options );
+        $this->guzzle = $guzzle;
+    }
+
+    public function updateContent($contentId)
+    {
+        $this->notify( array( array( 'action' => 'update', 'uri' => $this->getContentUri( $contentId ) ) ) );
+    }
+
+    public function deleteContent($contentId)
+    {
+        $this->notify( array( array( 'action' => 'delete', 'uri' => $this->getContentUri( $contentId ) ) ) );
+    }
+
+    /**
+     * Generates the REST URI of content $contentId
+     *
+     * @param $contentId
+     *
+     * @return string
+     */
+    protected function getContentUri( $contentId )
+    {
+        return sprintf(
+            '%s/api/ezp/v2/content/objects/%s',
+            $this->options['base-uri'],
+            $contentId
+        );
+    }
+
+    /**
+     * Notifies the YooChoose API of one or more repository events.
+     *
+     * A repository event is defined as an array with two keys:
+     * - action: the event name (update, delete)
+     * - uri: the event's target, as an absolute HTTP URI to the REST resource.
+     *
+     * @param array $events
+     *
+     * @throws \RuntimeException if the API request doesn't return the expected HTTP status code (202)
+     */
+    protected function notify( array $events )
+    {
+        foreach ( $events as $event )
+        {
+            if ( array_keys( $event ) != array( 'action', 'uri' ) )
+            {
+                throw new InvalidArgumentException( 'Invalid action keys' );
+            }
+        }
+
+        $response = $this->guzzle->post(
+            $this->getNotificationEndpoint(),
+            array( 'json' => array( 'transaction' => null, 'events' => $events ) )
+        );
+
+        if ( $response->getStatusCode() != 202 )
+        {
+            throw new RuntimeException( 'Unexpected status code ' . $response->getStatusCode() );
+        }
+    }
+
+    /**
+     * @param OptionsResolver $resolver
+     */
+    protected function configureOptions( OptionsResolver $resolver )
+    {
+        $options = array( 'customer-id', 'license-key', 'api-endpoint', 'base-uri' );
+        $resolver->setDefined( $options );
+        $resolver->setRequired( $options );
+    }
+
+    /**
+     * Returns the yoochoose notification endpoint
+     *
+     * @return string
+     */
+    private function getNotificationEndpoint()
+    {
+        return sprintf(
+            '%s/api/v1/publisher/ez/%s/notifications',
+            $this->options['api-endpoint'],
+            $this->options['customer-id']
+        );
+    }
+}

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,4 +1,20 @@
 parameters:
+    ez_recommendation.client.yoochoose_notifier.class: EzSystems\RecommendationBundle\Client\YooChooseNotifier
 
 services:
+    ez_recommendation.client.yoochoose_notifier:
+        class: %ez_recommendation.client.yoochoose_notifier.class%
+        arguments:
+            -
+                customer-id: %ez_recommendation.customer_id%
+                license-key: %ez_recommendation.license_key%
+                api-endpoint: %ez_recommendation.api_endpoint%
+                base-uri: http://php55-vm.ezpublish5
+            - @ez_recommendation.client.yoochoose_notifier.guzzle_client
 
+    ez_recommendation.client.yoochoose_notifier.guzzle_client:
+        class: GuzzleHttp\Client
+        arguments:
+            -
+                base_url: %ez_recommendation.api_endpoint%
+                defaults: {"auth": [%ez_recommendation.customer_id%, %ez_recommendation.license_key%]}

--- a/Tests/Client/YooChooseNotifierTest.php
+++ b/Tests/Client/YooChooseNotifierTest.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributd with this source code.
+ */
+
+namespace EzSystems\RecommendationBundle\Tests\Client;
+
+use EzSystems\RecommendationBundle\Client\YooChooseNotifier;
+use Guzzle\Http\Message\Response;
+use GuzzleHttp\ClientInterface;
+use PHPUnit_Framework_TestCase;
+
+class YooChooseNotifierTest extends PHPUnit_Framework_TestCase
+{
+    /** @var \EzSystems\RecommendationBundle\Client\YooChooseNotifier */
+    protected $notifier;
+
+    /** @var \GuzzleHttp\ClientInterface|\PHPUnit_Framework_MockObject_MockObject */
+    protected $guzzleClientMock;
+
+    public function setUp()
+    {
+        $this->notifier = new YooChooseNotifier(
+            array(
+                'customer-id' => '12345',
+                'license-key' => '1234-5678-9012-3456-7890',
+                'api-endpoint' => 'http://yoochoose.example.com',
+                'base-uri' => 'http://example.com'
+            ),
+            $this->guzzleClientMock = $this->getMock( 'GuzzleHttp\ClientInterface' )
+        );
+    }
+
+    public function testUpdateContent()
+    {
+        $this->setGuzzleExpectations( 'update', 31415 );
+        $this->notifier->updateContent( 31415 );
+    }
+
+    public function testDeleteContent()
+    {
+        $this->setGuzzleExpectations( 'delete', 31415 );
+        $this->notifier->deleteContent( 31415 );
+    }
+
+    protected function getNotificationBody( $action, $contentId )
+    {
+        return array(
+            'json' => array(
+                'transaction' => null,
+                'events' => array(
+                    array(
+                        'action' => $action,
+                        'uri' => 'http://example.com/api/ezp/v2/content/objects/' . $contentId
+                    )
+                )
+            )
+        );
+    }
+
+    /**
+     * Returns the expected API endpoint for notifications
+     * @return string
+     */
+    protected function getExpectedEndpoint()
+    {
+        return 'http://yoochoose.example.com/api/v1/publisher/ez/12345/notifications';
+    }
+
+    protected function setGuzzleExpectations( $action, $contentId )
+    {
+        $this->guzzleClientMock
+            ->expects( $this->once() )
+            ->method( 'post' )
+            ->with(
+                $this->equalTo( $this->getExpectedEndpoint() ),
+                $this->equalTo( $this->getNotificationBody( $action, $contentId ) )
+            )
+            ->will( $this->returnValue( new Response( 202 ) ) );
+    }
+}


### PR DESCRIPTION
> [EZP-23762](https://jira.ez.no/browse/EZP-23762)
> [REST API doc](http://docs.ezreco.apiary.io/#post-%2Fapi%2Fv4%2Fpublisher%2Fez%2F%7Bmandator%7D%2Fnotifications)

Implements an `ez_recommendation.client.yoochoose_notifier`, instance of `Client\YooChooseNotifier`, that implements `Client\RecommendationClient`.

This implementation notifies the YooChoose server, using the REST API, of changes to content, and is meant to be implemented in the API's SignalSlot. It uses Guzzle as the HTTP client.

The client is unit tested.
### Usage example

```
$client = $container->get( 'ez_recommendation.client.yoochoose_notifier' );
$client->updateContent( 12345 );
$client->deleteContent( 54321 );
```
