### PR TITLE
Fix EZP-23856: handled 'optional' addNodeAssignment method

### DIFF
--- a/eZ/Publish/LegacySearch/RecommendationLegacySearchEngine.php
+++ b/eZ/Publish/LegacySearch/RecommendationLegacySearchEngine.php
@@ -76,10 +76,13 @@ class RecommendationLegacySearchEngine implements ezpSearchEngine
         $this->legacySearchEngine->commit();
     }
 
-    public function addNodeAssignment( $mainNodeID, $objectID, $nodeAssignmentIDList, $isMoved )
+    public function addNodeAssignment( $mainNodeID, $objectID, $nodeAssignmentIDList, $isMoved = false )
     {
         $this->recommendationClient->updateContent( $objectID );
-        $this->legacySearchEngine->addNodeAssignment( $mainNodeID, $objectID, $nodeAssignmentIDList, $isMoved );
+        if ( method_exists( $this->legacySearchEngine, 'addNodeAssignment' ) )
+        {
+            $this->legacySearchEngine->addNodeAssignment( $mainNodeID, $objectID, $nodeAssignmentIDList, $isMoved );
+        }
     }
 
     public static function buildLegacySearchEngine($legacyKernelClosure)


### PR DESCRIPTION
> Fixes [EZP-23856](https://jira.ez.no/browse/EZP-23856)

The `addNodeAssignment()` method isn't part of the eZSearch interface, and isn't implemented by the native search engine. Due to this, we get a fatal error if we move a node when using the native search engine (doesn't happen with eZ Find).
