### PR TITLE
(WIP) EZP-24779 fix: prevent error if image is related to non-existing object

### DIFF
--- a/Rest/Field/Value.php
+++ b/Rest/Field/Value.php
@@ -101,7 +101,9 @@ class Value
         } elseif (in_array('ezobjectrelation', $fieldDefinitions) && !$related) {
             $field = $content->getFieldValue($fieldNames['ezobjectrelation'], $language);
 
-            return $this->getImageFieldIdentifier($field->destinationContentId, $language, true);
+            if (!empty($field->destinationContentId)) {
+                return $this->getImageFieldIdentifier($field->destinationContentId, $language, true);
+            }
         } else {
             return $this->getConfiguredFieldIdentifier('image', $contentType);
         }


### PR DESCRIPTION
Related JIRA ticket: https://jira.ez.no/browse/EZP-24779

It may happen if database data is corrupted for unknown reason (possibly failed import from 3rd party system or human factor).

This simple fix prevents asking for related object with NULLed contentId.

Internal Server Error ```Invalid or Empty Node passed to getItem constructor.``` fixed. Now, on dev enviroment we get another error, yet I'm unsure if it's due to still corrupted data or just because image file is missing on dev enviroment:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<ErrorMessage media-type="application/vnd.ez.api.ErrorMessage+xml">
 <errorCode>406</errorCode>
 <errorMessage>Not Acceptable</errorMessage>
 <errorDescription>Argument 'BinaryFile::id' is invalid: 'var/ezflow_site/storage/images/media/amnh/images/learn-teach/mat/rotate_hope1/339816-1-eng-US/rotate_hope1.jpg' is wrong value in class 'BinaryFile'</errorDescription>
 <trace>#0 /usr/local/var/www/amnh/vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/IO/UrlRedecorator.php(37): eZ\Publish\Core\IO\UrlDecorator\Prefix-&gt;undecorate('var/ezflow_site...')
#1 /usr/local/var/www/amnh/vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/Image.php(205): eZ\Publish\Core\IO\UrlRedecorator-&gt;redecorateFromTarget('var/ezflow_site...')
#2 /usr/local/var/www/amnh/vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/Image.php(173): eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Image-&gt;parseLegacyXml('&lt;?xml version=&quot;...')
#3 /usr/local/var/www/amnh/vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/Persistence/Legacy/Content/Mapper.php(419): eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Image-&gt;toFieldValue(Object(eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldValue), Object(eZ\Publish\SPI\Persistence\Content\FieldValue))
#4 /usr/local/var/www/amnh/vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/Persistence/Legacy/Content/Mapper.php(382): eZ\Publish\Core\Persistence\Legacy\Content\Mapper-&gt;extractFieldValueFromRow(Array, 'ezimage')
#5 /usr/local/var/www/amnh/vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/Persistence/Legacy/Content/Mapper.php(212): eZ\Publish\Core\Persistence\Legacy\Content\Mapper-&gt;extractFieldFromRow(Array)
#6 /usr/local/var/www/amnh/vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/Persistence/Legacy/Content/Handler.php(327): eZ\Publish\Core\Persistence\Legacy\Content\Mapper-&gt;extractContentFromRows(Array)
#7 /usr/local/var/www/amnh/ezpublish/cache/dev/ezpublishDevDebugProjectContainer.php(35332): eZ\Publish\Core\Persistence\Legacy\Content\Handler-&gt;load(27087, 1, NULL)
#8 /usr/local/var/www/amnh/vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/Persistence/Cache/ContentHandler.php(70): eZPublishCorePersistenceLegacyContentHandler_000000003198af620000000102fa0aac-&gt;load(27087, 1, NULL)
#9 /usr/local/var/www/amnh/vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/Repository/ContentService.php(409): eZ\Publish\Core\Persistence\Cache\ContentHandler-&gt;load(27087, 1, NULL)
#10 /usr/local/var/www/amnh/vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/Repository/ContentService.php(343): eZ\Publish\Core\Repository\ContentService-&gt;internalLoadContent(27087, NULL, NULL, false, true)
#11 /usr/local/var/www/amnh/vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/SignalSlot/ContentService.php(194): eZ\Publish\Core\Repository\ContentService-&gt;loadContent(27087, NULL, NULL, true)
#12 /usr/local/var/www/amnh/ezpublish/cache/dev/ezpublishDevDebugProjectContainer.php(30390): eZ\Publish\Core\SignalSlot\ContentService-&gt;loadContent(27087, NULL, NULL, true)
#13 /usr/local/var/www/amnh/src/EzSystems/RecommendationBundle/Rest/Field/Value.php(97): eZPublishCoreRepositoryContentService_000000003198a9730000000102fa0aac-&gt;loadContent(27087)
#14 /usr/local/var/www/amnh/src/EzSystems/RecommendationBundle/Rest/Field/Value.php(108): EzSystems\RecommendationBundle\Rest\Field\Value-&gt;getImageFieldIdentifier(27087, 'eng-US', true)
#15 /usr/local/var/www/amnh/src/EzSystems/RecommendationBundle/Rest/Field/Value.php(64): EzSystems\RecommendationBundle\Rest\Field\Value-&gt;getImageFieldIdentifier(845, 'eng-US')
#16 /usr/local/var/www/amnh/src/EzSystems/RecommendationBundle/Rest/Controller/ContentController.php(148): EzSystems\RecommendationBundle\Rest\Field\Value-&gt;getFieldValue(Object(eZ\Publish\Core\Repository\Values\Content\Content), 'title', 'eng-US')
#17 /usr/local/var/www/amnh/src/EzSystems/RecommendationBundle/Rest/Controller/ContentTypeController.php(70): EzSystems\RecommendationBundle\Rest\Controller\ContentController-&gt;prepareContent(Array)
#18 /usr/local/var/www/amnh/src/EzSystems/RecommendationBundle/Rest/Controller/ContentTypeController.php(33): EzSystems\RecommendationBundle\Rest\Controller\ContentTypeController-&gt;prepareContentByContentTypeIds(Array)
#19 [internal function]: EzSystems\RecommendationBundle\Rest\Controller\ContentTypeController-&gt;getContentType('52,41')
#20 /usr/local/var/www/amnh/vendor/symfony/symfony/src/Symfony/Component/HttpKernel/HttpKernel.php(145): call_user_func_array(Array, Array)
#21 /usr/local/var/www/amnh/vendor/symfony/symfony/src/Symfony/Component/HttpKernel/HttpKernel.php(66): Symfony\Component\HttpKernel\HttpKernel-&gt;handleRaw(Object(Symfony\Component\HttpFoundation\Request), 1)
#22 /usr/local/var/www/amnh/vendor/symfony/symfony/src/Symfony/Component/HttpKernel/DependencyInjection/ContainerAwareHttpKernel.php(64): Symfony\Component\HttpKernel\HttpKernel-&gt;handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#23 /usr/local/var/www/amnh/vendor/symfony/symfony/src/Symfony/Component/HttpKernel/Kernel.php(186): Symfony\Component\HttpKernel\DependencyInjection\ContainerAwareHttpKernel-&gt;handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#24 /usr/local/var/www/amnh/web/index.php(77): Symfony\Component\HttpKernel\Kernel-&gt;handle(Object(Symfony\Component\HttpFoundation\Request))
#25 {main}</trace>
 <file>/usr/local/var/www/amnh/vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/IO/UrlDecorator/Prefix.php</file>
 <line>58</line>
</ErrorMessage>```