### PR TITLE
fix: leave original field identifier for related field

### DIFF
--- a/Rest/Field/Value.php
+++ b/Rest/Field/Value.php
@@ -65,7 +65,6 @@ class Value
 
         if ($relatedField) {
             $content = $this->contentService->loadContent($relatedField);
-            $field = $imageFieldIdentifier;
         }
 
         $value = '';


### PR DESCRIPTION
We shouldn't remove original field identifier name from related object. It's misleading for end users, as they ask for ie. "image" and can get any identifier in result.