### PR TITLE
fix: change default content language to object lang instead of type lang

### DIFF
--- a/Rest/Controller/ContentController.php
+++ b/Rest/Controller/ContentController.php
@@ -120,7 +120,7 @@ class ContentController extends BaseController
             $contentValue = $contentValue->valueObject;
             $contentType = $this->contentTypeService->loadContentType($contentValue->contentInfo->contentTypeId);
             $location = $this->locationService->loadLocation($contentValue->contentInfo->mainLocationId);
-            $language = (null === $requestLanguage) ? $contentType->mainLanguageCode : $requestLanguage;
+            $language = (null === $requestLanguage) ? $location->contentInfo->mainLanguageCode : $requestLanguage;
             $this->value->setFieldDefinitionsList($contentType);
 
             $content[$contentValue->id] = array(


### PR DESCRIPTION
As default language we take content type language and not language of actual content object. It results in empty values if content is in different language from its content type language.