### PR TITLE
fix: configurable mapping should be more precise

### DIFF
--- a/Exception/InvalidRelationException.php
+++ b/Exception/InvalidRelationException.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * This file is part of the EzSystemsRecommendationBundle package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RecommendationBundle\Exception;
+
+use Exception;
+
+/**
+ * Generates InvalidRelationException with customised message.
+ *
+ * @param \Exception|null $previous
+ */
+class InvalidRelationException extends \InvalidArgumentException
+{
+    public function __construct($message, Exception $previous = null)
+    {
+        parent::__construct(
+            $message, 0, $previous
+        );
+    }
+}

--- a/Resources/config/default_settings.yml
+++ b/Resources/config/default_settings.yml
@@ -9,3 +9,5 @@ parameters:
     ez_recommendation.recommender.consume_timeout: 20
     ez_recommendation.tracking.api_endpoint: 'http://event.yoochoose.net'
     ez_recommendation.tracking.script_url: 'cdn.yoochoose.net/yct.js'
+
+    ez_recommendation.relations: []

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -6,6 +6,7 @@ parameters:
     ez_recommendation.value_object_visitor.content_data.class: EzSystems\RecommendationBundle\Rest\ValueObjectVisitor\ContentData
     ez_recommendation.rest.controller.content.class: EzSystems\RecommendationBundle\Rest\Controller\ContentController
     ez_recommendation.rest.controller.contenttype.class: EzSystems\RecommendationBundle\Rest\Controller\ContentTypeController
+    ez_recommendation.field.relation_mapper.class: EzSystems\RecommendationBundle\Rest\Field\RelationMapper
 
 services:
     ez_recommendation.client.yoochoose_notifier:
@@ -110,6 +111,11 @@ services:
             - @ez_recommendation.rest.field.value
         parent: ezpublish_rest.controller.base
 
+    ez_recommendation.field.relation_mapper:
+        class: %ez_recommendation.field.relation_mapper.class%
+        arguments:
+            - %ez_recommendation.relations%
+
     ez_recommendation.rest.controller.contenttype:
         class: %ez_recommendation.rest.controller.contenttype.class%
         parent: ez_recommendation.rest.controller.content
@@ -121,6 +127,7 @@ services:
             - @ezpublish.api.service.content_type
             - @ez_recommendation.rest.field.type_value
             - {fieldIdentifiers: %ez_recommendation.field_identifiers%}
+            - @ez_recommendation.field.relation_mapper
 
     ez_recommendation.rest.field.type_value:
         class: EzSystems\RecommendationBundle\Rest\Field\TypeValue

--- a/Rest/Field/RelationMapper.php
+++ b/Rest/Field/RelationMapper.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * This file is part of the EzSystemsRecommendationBundle package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RecommendationBundle\Rest\Field;
+
+class RelationMapper
+{
+    /** @var array $fieldMapping */
+    protected $fieldMappings;
+
+    /**
+     * @param array $fieldMapping
+     */
+    public function __construct(array $fieldMappings)
+    {
+        $this->fieldMappings = $fieldMappings;
+    }
+
+    /**
+     * Get related mapping for specified content and field.
+     *
+     * @param string $contentTypeIdentifier
+     * @param string $fieldIdentifier
+     *
+     * @return mixed Returns mathing mapping array or false if no matching mapping found
+     */
+    public function getMapping($contentTypeIdentifier, $fieldIdentifier)
+    {
+        $key = $contentTypeIdentifier . '.' . $fieldIdentifier;
+
+        if (!isset($this->fieldMappings[$key])) {
+            return false;
+        }
+
+        $identifier = explode('.', $this->fieldMappings[$key]);
+
+        return array(
+            'content' => $identifier[0],
+            'field' => $identifier[1],
+        );
+    }
+}


### PR DESCRIPTION
Previously if related content had two or more matching fields we picked the last one, regardless if it's correct one or not. Now, by configuration, customer is able to point `content.field` to another `content.field`.

Example configuration (`parameters.yml`):

```yaml
parameters:
    # ...
    ez_recommendation.relations:
        article.image: image.image_thumb
        cat.photo: gallery.main_image
        # and so on...
```