### PR TITLE
fix: log wrong relation and return empty value instead of uncaught exception

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -130,6 +130,7 @@ services:
             - @ez_recommendation.rest.field.type_value
             - {fieldIdentifiers: %ez_recommendation.field_identifiers%}
             - @ez_recommendation.field.relation_mapper
+            - @?logger
 
     ez_recommendation.rest.field.type_value:
         class: EzSystems\RecommendationBundle\Rest\Field\TypeValue


### PR DESCRIPTION
In result it will log a descriptive information about wrong relation and return empty field value instead of `Internal Server Error`

Log example: `[2015-10-01 15:34:18] app.WARNING: Invalid relation: field 'blog_post:image' (object: 73784, field: 1382616) has improper relation to object 'folder' (object: 62315); 'image:image' expected. [] []`