### PR TITLE
fix: return empty value if source binary file is missing

### DIFF
--- a/Rest/Field/TypeValue.php
+++ b/Rest/Field/TypeValue.php
@@ -9,6 +9,7 @@ namespace EzSystems\RecommendationBundle\Rest\Field;
 
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigResolver;
 use eZ\Bundle\EzPublishCoreBundle\Imagine\AliasGenerator as ImageVariationService;
+use eZ\Publish\Core\MVC\Exception\SourceImageNotFoundException;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\Field;
 use eZ\Publish\Core\FieldType\XmlText\Converter\Html5;
@@ -98,7 +99,11 @@ class TypeValue
             $variation = $requestedVariation;
         }
 
-        return $this->imageVariationService->getVariation($field, $content->versionInfo, $variation)->uri;
+        try {
+            return $this->imageVariationService->getVariation($field, $content->versionInfo, $variation)->uri;
+        } catch (SourceImageNotFoundException $exception) {
+            return '';
+        }
     }
 
     /**


### PR DESCRIPTION
Right now we do not catch `SourceImageNotFoundException` so it may result in `500 Internal Server Error` in case of missing binary file.

**Note**: This does not fix `Argument 'BinaryFile::id' is invalid` error (different origin).