### PR TITLE
Fix EZP-25904: Prevent crash when discarding draft

### DIFF
--- a/Client/YooChooseNotifier.php
+++ b/Client/YooChooseNotifier.php
@@ -138,7 +138,12 @@ class YooChooseNotifier implements RecommendationClient
      */
     public function deleteContent($contentId)
     {
-        if (!in_array($this->getContentIdentifier($contentId), $this->options['included-content-types'])) {
+        try {
+            if (!in_array($this->getContentIdentifier($contentId), $this->options['included-content-types'])) {
+                return;
+            }
+        } catch( \eZ\Publish\Core\Base\Exceptions\NotFoundException $e ) {
+            // This is an internal draft
             return;
         }
 


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-25904

It's OK if we skip the content item if it's not found with a first draft because the content item would not have been added to YooChoose anyway.