### PR TITLE
Fix EZP-25898: Prevent crash when updating non-public content item

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -15,6 +15,7 @@ services:
             - @ez_recommendation.client.yoochoose_notifier.guzzle_client
             - @ezpublish.api.service.content
             - @ezpublish.api.service.content_type
+            - @ezpublish.api.repository
             - {api-endpoint: %ez_recommendation.api_endpoint%}
             - @?logger
         calls:


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-25898

This is mostly for illustration purposes for an official patch to be developed:
* The cronjob is run as the anonymous user
* The anonymous user has no permissions to access the content item, even to check its content type
* There's a possible additional issue if the content item no longer exists, although that exception should probably be caught in getContentIdentifier() itself 