### PR TITLE
POC: Update Solr on hide/reveal of node

### DIFF
--- a/eZ/Publish/LegacySearch/RecommendationLegacySearchEngine.php
+++ b/eZ/Publish/LegacySearch/RecommendationLegacySearchEngine.php
@@ -80,4 +80,13 @@ class RecommendationLegacySearchEngine implements ezpSearchEngine
             $this->legacySearchEngine->addNodeAssignment($mainNodeID, $objectID, $nodeAssignmentIDList, $isMoved);
         }
     }
+
+    public function updateNodeVisibility($nodeID, $action)
+    {
+        // TODO: fetch the object ID
+        // $this->recommendationClient->updateContent($objectID);
+        if (method_exists($this->legacySearchEngine, 'updateNodeVisibility')) {
+            $this->legacySearchEngine->updateNodeVisibility($nodeID, $action);
+        }
+    }
 }


### PR DESCRIPTION
Sorry I didn't reference a public issue, but I created an Enterprise issue for it, so I presume a public issue will be created out of that.

In short, eZ Recommendation Engine causes a regression for an old fix to eZ Find that made sure the index was up to date whenever content was hidden or revealed (https://jira.ez.no/browse/EZP-15722).

There's a bigger concern regarding this: what other important functions get missed? Update on section, node swaps, object state, and more?