### PR TITLE
EZP-26034: Re add guzzle5 & PHP 5.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 sudo: false
 
 php:
+  - 5.4
   - 5.5
   - 5.6
 

--- a/Client/YooChooseNotifier.php
+++ b/Client/YooChooseNotifier.php
@@ -291,13 +291,13 @@ class YooChooseNotifier implements RecommendationClient
     }
 
     /**
-     * Notifies the YooChoose API using Guzzle 6.
+     * Notifies the YooChoose API using Guzzle 6 asynchronously.
      *
      * @param array $events
      */
     private function notifyGuzzle6(array $events)
     {
-        $response = $this->guzzle->request(
+        $promise = $this->guzzle->requestAsync(
             'POST',
             $this->getNotificationEndpoint(),
             array(
@@ -313,7 +313,7 @@ class YooChooseNotifier implements RecommendationClient
         );
 
         if (isset($this->logger)) {
-            $this->logger->debug('Got ' . $response->getStatusCode() . ' from YooChoose notification POST');
+            $this->logger->debug('Got asynchronously ' . $promise->getState() . ' from YooChoose notification POST');
         }
     }
 

--- a/Tests/Client/YooChooseNotifierTest.php
+++ b/Tests/Client/YooChooseNotifierTest.php
@@ -5,8 +5,9 @@
  */
 namespace EzSystems\RecommendationBundle\Tests\Client;
 
-use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Response as PSR7Response;
 use PHPUnit_Framework_TestCase;
+use GuzzleHttp\Message\Response;
 use eZ\Publish\Core\Repository\Values\Content\Content;
 use eZ\Publish\Core\Repository\Values\ContentType\ContentType;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
@@ -145,17 +146,30 @@ class YooChooseNotifierTest extends PHPUnit_Framework_TestCase
         $licenseKey,
         $apiEndpoint
     ) {
-        $this->guzzleClientMock
-            ->expects($this->once())
-            ->method('request')
-            ->with(
-                'POST',
-                $this->equalTo($this->getExpectedEndpoint($apiEndpoint, $customerId)),
-                $this->equalTo($this->getNotificationBody(
-                    $action, $contentId, $contentTypeId, $serverUri, $customerId, $licenseKey
-                ))
-            )
-            ->will($this->returnValue(new Response(202)));
+        if (method_exists($this->guzzleClientMock, 'post')) {
+            $this->guzzleClientMock
+                ->expects($this->once())
+                ->method('post')
+                ->with(
+                    $this->equalTo($this->getExpectedEndpoint($apiEndpoint, $customerId)),
+                    $this->equalTo($this->getNotificationBody(
+                        $action, $contentId, $contentTypeId, $serverUri, $customerId, $licenseKey
+                    ))
+                )
+                ->will($this->returnValue(new Response(202)));
+        } else {
+            $this->guzzleClientMock
+                ->expects($this->once())
+                ->method('request')
+                ->with(
+                    'POST',
+                    $this->equalTo($this->getExpectedEndpoint($apiEndpoint, $customerId)),
+                    $this->equalTo($this->getNotificationBody(
+                        $action, $contentId, $contentTypeId, $serverUri, $customerId, $licenseKey
+                    ))
+                )
+                ->will($this->returnValue(new PSR7Response(200)));
+        }
     }
 
     /**

--- a/Tests/Client/YooChooseNotifierTest.php
+++ b/Tests/Client/YooChooseNotifierTest.php
@@ -5,9 +5,9 @@
  */
 namespace EzSystems\RecommendationBundle\Tests\Client;
 
-use GuzzleHttp\Psr7\Response as PSR7Response;
 use PHPUnit_Framework_TestCase;
 use GuzzleHttp\Message\Response;
+use GuzzleHttp\Promise\Promise;
 use eZ\Publish\Core\Repository\Values\Content\Content;
 use eZ\Publish\Core\Repository\Values\ContentType\ContentType;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
@@ -160,7 +160,7 @@ class YooChooseNotifierTest extends PHPUnit_Framework_TestCase
         } else {
             $this->guzzleClientMock
                 ->expects($this->once())
-                ->method('request')
+                ->method('requestAsync')
                 ->with(
                     'POST',
                     $this->equalTo($this->getExpectedEndpoint($apiEndpoint, $customerId)),
@@ -168,7 +168,7 @@ class YooChooseNotifierTest extends PHPUnit_Framework_TestCase
                         $action, $contentId, $contentTypeId, $serverUri, $customerId, $licenseKey
                     ))
                 )
-                ->will($this->returnValue(new PSR7Response(200)));
+                ->will($this->returnValue(new Promise()));
         }
     }
 

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         }
     ],
     "require": {
-        "guzzlehttp/guzzle": "~6.0",
+        "guzzlehttp/guzzle": "~5.0|~6.0",
         "components/handlebars.js": "~3.0.0",
         "symfony/symfony": "~2.6"
     },


### PR DESCRIPTION
Issue: https://jira.ez.no/browse/EZP-26034

Adapts code to support both Guzzle5 and Guzzle6 at the same time, and re enable PHP 5.4 testing.

While on it, also take advantage of asynchronous http support in Guzzle 6.
Once passed, reviewed  and merged we'll need a `v1.0.2-rc1` tag for ongoing eZ Publish 5.4.7 QA.

review ping @lserwatka @clash82 