### PR TITLE
[Travis] Update use of travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
     include:
         - php: 7.0
         - php: 5.6
+          env: SYMFONY_VERSION="~3.0" KERNEL_VERSION="dev-sf3 as 6.6.x-dev"
         - php: 5.5
         - php: 5.4
           env: SYMFONY_VERSION="~2.7.0"
@@ -26,9 +27,10 @@ before_script:
   - if [ $TRAVIS_PHP_VERSION != "hhvm" ]; then phpenv config-rm xdebug.ini ; fi
   - echo 'memory_limit = -1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   # If set update symfony version
-  - if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/symfony=$SYMFONY_VERSION; fi;
+  - if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/symfony="$SYMFONY_VERSION"; fi;
+  - if [ "$KERNEL_VERSION" != "" ]; then composer require --dev --no-update ezsystems/ezpublish-kernel="$KERNEL_VERSION"; fi;
   # Install packages using composer
-  - composer install --dev --prefer-dist
+  - composer install  --prefer-dist
   # Detecting timezone issues by testing on random timezone
   - TEST_TIMEZONES=("America/New_York" "Asia/Calcutta" "UTC")
   - TEST_TIMEZONE=${TEST_TIMEZONES["`shuf -i 0-2 -n 1`"]}

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ matrix:
     include:
         - php: 7.0
         - php: 5.6
-          env: SYMFONY_VERSION="~3.0" KERNEL_VERSION="dev-sf3 as 6.6.x-dev"
         - php: 5.5
         - php: 5.4
           env: SYMFONY_VERSION="~2.7.0"
@@ -27,10 +26,9 @@ before_script:
   - if [ $TRAVIS_PHP_VERSION != "hhvm" ]; then phpenv config-rm xdebug.ini ; fi
   - echo 'memory_limit = -1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   # If set update symfony version
-  - if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/symfony="$SYMFONY_VERSION"; fi;
-  - if [ "$KERNEL_VERSION" != "" ]; then composer require --dev --no-update ezsystems/ezpublish-kernel="$KERNEL_VERSION"; fi;
+  - if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/symfony=$SYMFONY_VERSION; fi;
   # Install packages using composer
-  - composer install  --prefer-dist
+  - composer install --dev --prefer-dist
   # Detecting timezone issues by testing on random timezone
   - TEST_TIMEZONES=("America/New_York" "Asia/Calcutta" "UTC")
   - TEST_TIMEZONE=${TEST_TIMEZONES["`shuf -i 0-2 -n 1`"]}

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,26 +2,30 @@ language: php
 
 sudo: false
 
-php:
-  - 5.4
-  - 5.5
-  - 5.6
-
+cache:
+  directories:
+    - $HOME/.composer/cache/files
+    
+matrix:
+    fast_finish: true
+    include:
+        - php: 7.0
+        - php: 5.6
+        - php: 5.5
+        - php: 5.4
+          env: SYMFONY_VERSION="~2.7.0"
 
 # test only master (+ Pull requests)
 branches:
   only:
     - master
+    - /^\d.\d+$/
 
 before_script:
   # Disable xdebug to speed things up as we don't currently generate coverge on travis
   - if [ $TRAVIS_PHP_VERSION != "hhvm" ]; then phpenv config-rm xdebug.ini ; fi
-  # Update composer to newest version
-  - composer self-update
-  # Randomize Symfony versions
-  - SYMFONY_VERSIONS=("~2.7.0" "~2.6.0" "")
-  - SYMFONY_VERSION=${SYMFONY_VERSIONS["`shuf -i 0-2 -n 1`"]}
-  - echo "$SYMFONY_VERSION"
+  - echo 'memory_limit = -1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+  # If set update symfony version
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/symfony=$SYMFONY_VERSION; fi;
   # Install packages using composer
   - composer install --dev --prefer-dist


### PR DESCRIPTION
attempt to:
- fix memory limit issues
- use matrix and fast finish
- cache composer deps
- make sure stable branches are tested also
- get rid of random symfony version and rather specify in matrix *(and drop Symfony 2.6 as we don't use that anymore)*
- ~~try to test against Symfony 3.0 (using https://github.com/ezsystems/ezpublish-kernel/pull/1753)~~ \*


\* Fails, @alongosz you have yet another repo to look at here in regards to enabling depracted warnings to be able to run tests on 2.8 with them, and on Symfony 3.0 as attempted  in 	d99dd90, see failure on [travis](https://travis-ci.org/ezsystems/EzSystemsRecommendationBundle/jobs/154425828) ;)