### PR TITLE
EZP-26128: As a Developer I want deprecation issues resolved, so that application logs are clean

### DIFF
--- a/Client/YooChooseNotifier.php
+++ b/Client/YooChooseNotifier.php
@@ -323,8 +323,7 @@ class YooChooseNotifier implements RecommendationClient
     protected function configureOptions(OptionsResolver $resolver)
     {
         $options = array('customer-id', 'license-key', 'api-endpoint', 'server-uri');
-        // Could use setDefined() with symfony ~2.6
-        $resolver->setOptional($options);
+        $resolver->setDefined($options);
         $resolver->setDefaults(
             array(
                 'customer-id' => null,

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This bundle integrates Recommendation services into eZ Platform. It supports the
 ## Requirements
 
 - PHP 5.4.4 *or higher PHP 5.x version*
-- Symfony 2.6 *or higher Symfony 2.x version*
+- Symfony 2.7 *or higher Symfony 2.x version*
 - eZ Publish v5.4.1+ or eZ Platform/Studio v1.0+, with the REST API configured to use sessions and publicly open to the YOOCHOOSE servers.
 - A YOOCHOOSE subscription
 

--- a/Resources/config/routing_rest.yml
+++ b/Resources/config/routing_rest.yml
@@ -1,11 +1,11 @@
 recommendationBundle_getContent:
-    pattern: /ez_recommendation/v1/content/{contentIdList}
+    path: /ez_recommendation/v1/content/{contentIdList}
     defaults:
         _controller: ez_recommendation.rest.controller.content:getContent
     methods: [GET]
 
 recommendationBundle_getContentTypes:
-    pattern: /ez_recommendation/v1/contenttypes/{contentTypeIdList}
+    path: /ez_recommendation/v1/contenttypes/{contentTypeIdList}
     defaults:
         _controller: ez_recommendation.rest.controller.contenttype:getContentType
     methods: [GET]

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -10,12 +10,12 @@ parameters:
 
 services:
     ez_recommendation.client.yoochoose_notifier:
-        class: %ez_recommendation.client.yoochoose_notifier.class%
+        class: "%ez_recommendation.client.yoochoose_notifier.class%"
         arguments:
-            - @ez_recommendation.client.yoochoose_notifier.guzzle_client
-            - @ezpublish.api.repository
-            - {api-endpoint: %ez_recommendation.api_endpoint%}
-            - @?logger
+            - "@ez_recommendation.client.yoochoose_notifier.guzzle_client"
+            - "@ezpublish.api.repository"
+            - {api-endpoint: "%ez_recommendation.api_endpoint%"}
+            - "@?logger"
         calls:
             - [setCustomerId, [$yoochoose.customer_id;ez_recommendation$]]
             - [setLicenseKey, [$yoochoose.license_key;ez_recommendation$]]
@@ -27,7 +27,7 @@ services:
     ez_recommendation.client.yoochoose_notifier.guzzle_client:
         class: GuzzleHttp\Client
         arguments:
-            - { base_url: %ez_recommendation.api_endpoint% }
+            - { base_url: "%ez_recommendation.api_endpoint%" }
 
   # The configured eZ Publish Platform legacy search engine - enable lines below only if you're using legacy bridge.
 
@@ -35,38 +35,38 @@ services:
   #     class: ezpSearchEngine
   #     factory_class: EzSystems\RecommendationBundle\eZ\Publish\LegacySearch\LegacySearchFactory
   #     factory_method: build
-  #     arguments: [@ezpublish_legacy.kernel]
+  #     arguments: ["@ezpublish_legacy.kernel"]
 
   # ez_recommendation.legacy.recommendation_search_engine:
   #     class: EzSystems\RecommendationBundle\eZ\Publish\LegacySearch\RecommendationLegacySearchEngine
   #     arguments:
-  #         - @ez_recommendation.client.yoochoose_notifier
-  #         - @ez_recommendation.legacy.search_engine
+  #         - "@ez_recommendation.client.yoochoose_notifier"
+  #         - "@ez_recommendation.legacy.search_engine"
 
   # ez_recommendation.legacy.search_configuration_mapper:
   #     class: EzSystems\RecommendationBundle\eZ\Publish\LegacySearch\ConfigurationMapper
   #     arguments:
-  #         - @ez_recommendation.legacy.recommendation_search_engine
-  #         - @ezpublish.siteaccess
+  #         - "@ez_recommendation.legacy.recommendation_search_engine"
+  #         - "@ezpublish.siteaccess"
   #     tags:
   #         - { name: kernel.event_subscriber }
 
     ez_recommendation.twig.extension:
-        class: %ez_recommendation.twig.extension.class%
+        class: "%ez_recommendation.twig.extension.class%"
         public: true
         arguments:
-            - @request_stack
-            - @ezpublish.api.service.content_type
-            - @ezpublish.api.service.content
-            - @ezpublish.api.service.location
-            - @ezpublish.locale.converter
-            - @security.authorization_checker
-            - @security.token_storage
-            - @session
-            - recommenderEndPoint: %ez_recommendation.recommender.api_endpoint%
-              consumeTimeout: %ez_recommendation.recommender.consume_timeout%
-              trackingScriptUrl: %ez_recommendation.tracking.script_url%
-              trackingEndPoint: %ez_recommendation.tracking.api_endpoint%
+            - "@request_stack"
+            - "@ezpublish.api.service.content_type"
+            - "@ezpublish.api.service.content"
+            - "@ezpublish.api.service.location"
+            - "@ezpublish.locale.converter"
+            - "@security.authorization_checker"
+            - "@security.token_storage"
+            - "@session"
+            - recommenderEndPoint: "%ez_recommendation.recommender.api_endpoint%"
+              consumeTimeout: "%ez_recommendation.recommender.consume_timeout%"
+              trackingScriptUrl: "%ez_recommendation.tracking.script_url%"
+              trackingEndPoint: "%ez_recommendation.tracking.api_endpoint%"
         calls:
             - [setIncludedContentTypes, [$recommender.included_content_types;ez_recommendation$]]
             - [setCustomerId, [$yoochoose.customer_id;ez_recommendation$]]
@@ -74,13 +74,13 @@ services:
             - { name: twig.extension }
 
     ez_recommendation.event_listener.login:
-        class: %ez_recommendation.event_listener.login.class%
+        class: "%ez_recommendation.event_listener.login.class%"
         arguments:
-            - @security.authorization_checker
-            - @session
-            - @ez_recommendation.client.yoochoose_notifier.guzzle_client
-            - trackingEndPoint: %ez_recommendation.tracking.api_endpoint%
-            - @?logger
+            - "@security.authorization_checker"
+            - "@session"
+            - "@ez_recommendation.client.yoochoose_notifier.guzzle_client"
+            - trackingEndPoint: "%ez_recommendation.tracking.api_endpoint%"
+            - "@?logger"
         calls:
             - [setCustomerId, [$yoochoose.customer_id;ez_recommendation$]]
         tags:
@@ -88,54 +88,54 @@ services:
             - { name: monolog.logger, channel: ez_recommendation }
 
     ez_recommendation.event_listener.session_backup:
-        class: %ez_recommendation.event_listener.session_backup.class%
+        class: "%ez_recommendation.event_listener.session_backup.class%"
         arguments:
-            - @session
+            - "@session"
         tags:
             - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest }
 
     ez_recommendation.value_object_visitor.content_data:
         parent: ezpublish_rest.output.value_object_visitor.base
-        class: %ez_recommendation.value_object_visitor.content_data.class%
+        class: "%ez_recommendation.value_object_visitor.content_data.class%"
         tags:
             - { name: ezpublish_rest.output.value_object_visitor, type: EzSystems\RecommendationBundle\Rest\Values\ContentData }
 
     ez_recommendation.rest.controller.content:
-        class: %ez_recommendation.rest.controller.content.class%
+        class: "%ez_recommendation.rest.controller.content.class%"
         arguments:
-            - @ezpublish.urlalias_router
-            - @ezpublish.api.service.content
-            - @ezpublish.api.service.location
-            - @ezpublish.api.service.content_type
-            - @ezpublish.api.service.search
-            - @ez_recommendation.rest.field.value
-            - %ez_recommendation.default.author_id%
+            - "@ezpublish.urlalias_router"
+            - "@ezpublish.api.service.content"
+            - "@ezpublish.api.service.location"
+            - "@ezpublish.api.service.content_type"
+            - "@ezpublish.api.service.search"
+            - "@ez_recommendation.rest.field.value"
+            - "%ez_recommendation.default.author_id%"
         parent: ezpublish_rest.controller.base
 
     ez_recommendation.field.relation_mapper:
-        class: %ez_recommendation.field.relation_mapper.class%
+        class: "%ez_recommendation.field.relation_mapper.class%"
         arguments:
-            - %ez_recommendation.relations%
+            - "%ez_recommendation.relations%"
 
     ez_recommendation.rest.controller.contenttype:
-        class: %ez_recommendation.rest.controller.contenttype.class%
+        class: "%ez_recommendation.rest.controller.contenttype.class%"
         parent: ez_recommendation.rest.controller.content
 
     ez_recommendation.rest.field.value:
         class: EzSystems\RecommendationBundle\Rest\Field\Value
         arguments:
-            - @ezpublish.api.service.content
-            - @ezpublish.api.service.content_type
-            - @ez_recommendation.rest.field.type_value
-            - {fieldIdentifiers: %ez_recommendation.field_identifiers%}
-            - @ez_recommendation.field.relation_mapper
-            - @?logger
+            - "@ezpublish.api.service.content"
+            - "@ezpublish.api.service.content_type"
+            - "@ez_recommendation.rest.field.type_value"
+            - {fieldIdentifiers: "%ez_recommendation.field_identifiers%"}
+            - "@ez_recommendation.field.relation_mapper"
+            - "@?logger"
 
     ez_recommendation.rest.field.type_value:
         class: EzSystems\RecommendationBundle\Rest\Field\TypeValue
         arguments:
-            - @request_stack
-            - @ezpublish.config.resolver.core
-            - @ezpublish.image_alias.imagine.alias_generator
-            - @ezpublish.fieldtype.ezrichtext.converter.output.xhtml5.core
-            - @?ezpublish.fieldtype.ezxmltext.converter.html5
+            - "@request_stack"
+            - "@ezpublish.config.resolver.core"
+            - "@ezpublish.image_alias.imagine.alias_generator"
+            - "@ezpublish.fieldtype.ezrichtext.converter.output.xhtml5.core"
+            - "@?ezpublish.fieldtype.ezxmltext.converter.html5"

--- a/Resources/config/slots.yml
+++ b/Resources/config/slots.yml
@@ -17,92 +17,92 @@ parameters:
 
 services:
     ez_recommendation.ez_slot.base:
-        class: %ez_recommendation.ez_slot.base.class%
+        class: "%ez_recommendation.ez_slot.base.class%"
         abstract: true
         arguments:
-            - @ez_recommendation.client.yoochoose_notifier
+            - "@ez_recommendation.client.yoochoose_notifier"
 
     ez_recommendation.ez_slot.persistence_aware_base:
-        class: %ez_recommendation.ez_slot.persistence_aware_base.class%
+        class: "%ez_recommendation.ez_slot.persistence_aware_base.class%"
         abstract: true
         arguments:
-            - @ez_recommendation.client.yoochoose_notifier
-            - @ezpublish.api.persistence_handler
+            - "@ez_recommendation.client.yoochoose_notifier"
+            - "@ezpublish.api.persistence_handler"
 
     ez_recommendation.ez_slot.publish_version:
         parent: ez_recommendation.ez_slot.base
-        class: %ez_recommendation.ez_slot.publish_version.class%
+        class: "%ez_recommendation.ez_slot.publish_version.class%"
         tags:
             - {name: ezpublish.api.slot, signal: ContentService\PublishVersionSignal}
 
     ez_recommendation.ez_slot.copy_content:
         parent: ez_recommendation.ez_slot.base
-        class: %ez_recommendation.ez_slot.copy_content.class%
+        class: "%ez_recommendation.ez_slot.copy_content.class%"
         tags:
             - {name: ezpublish.api.slot, signal: ContentService\CopyContentSignal}
 
     ez_recommendation.ez_slot.delete_content:
         parent: ez_recommendation.ez_slot.base
-        class: %ez_recommendation.ez_slot.delete_content.class%
+        class: "%ez_recommendation.ez_slot.delete_content.class%"
         tags:
             - {name: ezpublish.api.slot, signal: ContentService\DeleteContentSignal}
 
     ez_recommendation.ez_slot.delete_version:
         parent: ez_recommendation.ez_slot.base
-        class: %ez_recommendation.ez_slot.delete_version.class%
+        class: "%ez_recommendation.ez_slot.delete_version.class%"
         tags:
             - {name: ezpublish.api.slot, signal: ContentService\DeleteVersionSignal}
 
     ez_recommendation.ez_slot.delete_location:
         parent: ez_recommendation.ez_slot.base
-        class: %ez_recommendation.ez_slot.delete_location.class%
+        class: "%ez_recommendation.ez_slot.delete_location.class%"
         tags:
             - {name: ezpublish.api.slot, signal: LocationService\DeleteLocationSignal}
 
     ez_recommendation.ez_slot.create_location:
         parent: ez_recommendation.ez_slot.base
-        class: %ez_recommendation.ez_slot.create_location.class%
+        class: "%ez_recommendation.ez_slot.create_location.class%"
         tags:
             - {name: ezpublish.api.slot, signal: LocationService\CreateLocationSignal}
 
     ez_recommendation.ez_slot.copy_subtree:
         parent: ez_recommendation.ez_slot.persistence_aware_base
-        class: %ez_recommendation.ez_slot.copy_subtree.class%
+        class: "%ez_recommendation.ez_slot.copy_subtree.class%"
         tags:
             - {name: ezpublish.api.slot, signal: LocationService\CopySubtreeSignal}
 
     ez_recommendation.ez_slot.move_subtree:
         parent: ez_recommendation.ez_slot.persistence_aware_base
-        class: %ez_recommendation.ez_slot.move_subtree.class%
+        class: "%ez_recommendation.ez_slot.move_subtree.class%"
         tags:
             - {name: ezpublish.api.slot, signal: LocationService\MoveSubtreeSignal}
 
     ez_recommendation.ez_slot.trash:
         parent: ez_recommendation.ez_slot.base
-        class: %ez_recommendation.ez_slot.trash.class%
+        class: "%ez_recommendation.ez_slot.trash.class%"
         tags:
             - {name: ezpublish.api.slot, signal: TrashService\TrashSignal}
 
     ez_recommendation.ez_slot.recover:
         parent: ez_recommendation.ez_slot.persistence_aware_base
-        class: %ez_recommendation.ez_slot.recover.class%
+        class: "%ez_recommendation.ez_slot.recover.class%"
         tags:
             - {name: ezpublish.api.slot, signal: TrashService\RecoverSignal}
 
     ez_recommendation.ez_slot.hide_location:
         parent: ez_recommendation.ez_slot.base
-        class: %ez_recommendation.ez_slot.hide_location.class%
+        class: "%ez_recommendation.ez_slot.hide_location.class%"
         tags:
             - {name: ezpublish.api.slot, signal: LocationService\HideLocationSignal}
 
     ez_recommendation.ez_slot.unhide_location:
         parent: ez_recommendation.ez_slot.base
-        class: %ez_recommendation.ez_slot.unhide_location.class%
+        class: "%ez_recommendation.ez_slot.unhide_location.class%"
         tags:
             - {name: ezpublish.api.slot, signal: LocationService\UnhideLocationSignal}
 
     ez_recommendation.ez_slot.set_content_state:
         parent: ez_recommendation.ez_slot.base
-        class: %ez_recommendation.ez_slot.set_content_state.class%
+        class: "%ez_recommendation.ez_slot.set_content_state.class%"
         tags:
             - {name: ezpublish.api.slot, signal: ObjectStateService\SetContentStateSignal}

--- a/Resources/views/default.html.twig
+++ b/Resources/views/default.html.twig
@@ -2,7 +2,7 @@
     https://doc.ez.no/display/DOCTEST/Customer+Attribute+Mappings to see the list of default field names. #}
 
 <script id="recommendations-template-{{ templateId }}" type="text/x-handlebars-template">
-    {% raw %}
+    {% verbatim %}
         <div class="content-view-line">
             {{#each this}}
                 <article class="class-article">
@@ -31,10 +31,10 @@
                     </div>
                 </article>
             {{else}}
-                <div class="content-view-line">{% endraw %}{{ 'No recommendations found'|trans }}{% raw %}</div>
+                <div class="content-view-line">{% endverbatim %}{{ 'No recommendations found'|trans }}{% verbatim %}</div>
             {{/each}}
         </div>
-    {% endraw %}
+    {% endverbatim %}
 </script>
 
 <div id="recommendations-target-{{ templateId }}"></div>

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "require": {
         "guzzlehttp/guzzle": "~5.0|~6.0",
         "components/handlebars.js": "~3.0.0",
-        "symfony/symfony": "~2.6"
+        "symfony/symfony": "^2.7.7"
     },
     "require-dev": {
         "ezsystems/ezpublish-kernel": "~6.0.0@beta | ~5.1",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,7 +10,9 @@
         convertWarningsToExceptions="true"
         colors="false"
         >
-
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
     <testsuites>
         <testsuite name="EzSystemsRecommendationBundle tests suite">
             <directory suffix="Test.php">./Tests</directory>


### PR DESCRIPTION
This PR Resolves [EZP-26128](https://jira.ez.no/browse/EZP-26128) for this repository.

It also allows us to move forward with Symfony `3.0` integration in the future (mentioned in #72 and related to [Kernel PR #1753](https://github.com/ezsystems/ezpublish-kernel/pull/1753)).

**TODO**:
- [x] Quote `@service` and `%parameter%` references in Yaml files (8d82e90).
- [x] Replace deprecated `OptionsResolved::setOptional` with `OptionsResolved::setDefined` to move forward with Symfony `3.0` integration (5865792).
- [x] Ensure unit tests are run with full error reporting (fa95342).
- [x] [~~BC Break~~](https://github.com/ezsystems/EzSystemsRecommendationBundle/pull/73#discussion_r76063500): Replace deprecated Twig tag `raw` with `verbatim`(2be93af).
- [x] Bump Symfony requirement to `^2.7.7` to ensure Twig version `~1.21` which introduces `verbatim` tag (9465756, a82594e).
- [x] Replace deprecated `pattern` option in route definitions with `path` (924737e).
