### PR TITLE
EZS-911 Initial bulk upload of content to Personalization Service

### DIFF
--- a/DependencyInjection/Compiler/RestResponsePass.php
+++ b/DependencyInjection/Compiler/RestResponsePass.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * This file is part of the EzSystemRecommendationBundle package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RecommendationBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class RestResponsePass implements CompilerPassInterface
+{
+    /**
+     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $visitor = $container->getDefinition('ez_recommendation.value_object_visitor.content_data');
+        $responseRenderers = [];
+
+        foreach ($container->findTaggedServiceIds('ez_recommendation.rest.response_type') as $id => $tags) {
+            $responseRenderers[$tags[0]['type']] = new Reference($id);
+        }
+
+        $visitor->addMethodCall('setResponseRendereres', [$responseRenderers]);
+    }
+}

--- a/EzSystemsRecommendationBundle.php
+++ b/EzSystemsRecommendationBundle.php
@@ -3,18 +3,23 @@
  * This file is part of the EzSystemRecommendationBundle package.
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
- * @license For full copyright and license information view LICENSE file distributd with this source code.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace EzSystems\RecommendationBundle;
 
 use EzSystems\RecommendationBundle\DependencyInjection\EzSystemsRecommendationExtension;
+use EzSystems\RecommendationBundle\DependencyInjection\Compiler\RestResponsePass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class EzSystemsRecommendationBundle extends Bundle
 {
-    /** @var EzSystemsRecommendationExtension */
+    /** @var \EzSystems\RecommendationBundle\DependencyInjection\EzSystemsRecommendationExtension */
     protected $extension;
 
+    /**
+     * @return \EzSystems\RecommendationBundle\DependencyInjection\EzSystemsRecommendationExtension
+     */
     public function getContainerExtension()
     {
         if (!isset($this->extension)) {
@@ -22,5 +27,15 @@ class EzSystemsRecommendationBundle extends Bundle
         }
 
         return $this->extension;
+    }
+
+    /**
+     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+     */
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(new RestResponsePass());
     }
 }

--- a/Resources/config/routing_rest.yml
+++ b/Resources/config/routing_rest.yml
@@ -1,11 +1,20 @@
 recommendationBundle_getContent:
-    path: /ez_recommendation/v1/content/{contentIdList}
+    path: /ez_recommendation/v1/content/{contentIdList}/{responseType}
     defaults:
         _controller: ez_recommendation.rest.controller.content:getContent
+        responseType: http
     methods: [GET]
 
 recommendationBundle_getContentTypes:
-    path: /ez_recommendation/v1/contenttypes/{contentTypeIdList}
+    path: /ez_recommendation/v1/contenttypes/{contentTypeIdList}/{responseType}
     defaults:
         _controller: ez_recommendation.rest.controller.contenttype:getContentType
+        responseType: http
     methods: [GET]
+
+recommendationBundle_downloadExportedContent:
+    path: /ez_recommendation/v1/exportDownload/{filePath}
+    defaults:
+        _controller: ez_recommendation.rest.controller.export:downloadAction
+    requirements:
+        filePath: "[0-9/]+"

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -166,7 +166,7 @@ services:
         class: "%ez_recommendation.rest.response.http.class%"
         parent: ez_recommendation.rest.response
         tags:
-            - { name: ez_recommendation.rest.response_type, type: http}
+            - { name: ez_recommendation.rest.response_type, type: http }
 
     ez_recommendation.rest.response.export:
         class: "%ez_recommendation.rest.response.export.class%"
@@ -174,5 +174,5 @@ services:
         calls:
             - [setApiEndpoint, ["%ez_recommendation.api_endpoint%"]]
         tags:
-            - { name: ez_recommendation.rest.response_type, type: export}
+            - { name: ez_recommendation.rest.response_type, type: export }
 

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -6,7 +6,12 @@ parameters:
     ez_recommendation.value_object_visitor.content_data.class: EzSystems\RecommendationBundle\Rest\ValueObjectVisitor\ContentData
     ez_recommendation.rest.controller.content.class: EzSystems\RecommendationBundle\Rest\Controller\ContentController
     ez_recommendation.rest.controller.contenttype.class: EzSystems\RecommendationBundle\Rest\Controller\ContentTypeController
+    ez_recommendation.rest.controller.export.class: EzSystems\RecommendationBundle\Rest\Controller\ExportController
     ez_recommendation.field.relation_mapper.class: EzSystems\RecommendationBundle\Rest\Field\RelationMapper
+    ez_recommendation.rest.response.class: EzSystems\RecommendationBundle\Rest\Response\Response
+    ez_recommendation.rest.response.http.class: EzSystems\RecommendationBundle\Rest\Response\HttpResponse
+    ez_recommendation.rest.response.export.class: EzSystems\RecommendationBundle\Rest\Response\ExportResponse
+    ez_recommendation.rest.visitor.generator.class: EzSystems\RecommendationBundle\Rest\ValueObjectVisitor\ContentListElementGenerator
 
 services:
     ez_recommendation.client.yoochoose_notifier:
@@ -114,6 +119,12 @@ services:
         parent: ezpublish_rest.controller.base
         calls:
             - [setSiteAccess, [@ezpublish.siteaccess]]
+            - [setCustomerId, [$yoochoose.customer_id;ez_recommendation$]]
+
+    ez_recommendation.rest.controller.export:
+        class: "%ez_recommendation.rest.controller.export.class%"
+        arguments:
+            - "@kernel"
 
     ez_recommendation.field.relation_mapper:
         class: "%ez_recommendation.field.relation_mapper.class%"
@@ -142,3 +153,26 @@ services:
             - "@ezpublish.image_alias.imagine.alias_generator"
             - "@ezpublish.fieldtype.ezrichtext.converter.output.xhtml5.core"
             - "@?ezpublish.fieldtype.ezxmltext.converter.html5"
+
+    ez_recommendation.rest.visitor.generator:
+        class: "%ez_recommendation.rest.visitor.generator.class%"
+
+    ez_recommendation.rest.response:
+        abstract: true
+        arguments:
+            - "@ez_recommendation.rest.visitor.generator"
+
+    ez_recommendation.rest.response.http:
+        class: "%ez_recommendation.rest.response.http.class%"
+        parent: ez_recommendation.rest.response
+        tags:
+            - { name: ez_recommendation.rest.response_type, type: http}
+
+    ez_recommendation.rest.response.export:
+        class: "%ez_recommendation.rest.response.export.class%"
+        parent: ez_recommendation.rest.response
+        calls:
+            - [setApiEndpoint, ["%ez_recommendation.api_endpoint%"]]
+        tags:
+            - { name: ez_recommendation.rest.response_type, type: export}
+

--- a/Rest/Controller/ContentController.php
+++ b/Rest/Controller/ContentController.php
@@ -16,6 +16,7 @@ use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\API\Repository\ContentTypeService;
 use eZ\Publish\API\Repository\SearchService;
+use EzSystems\RecommendationBundle\Rest\Exception\UnsupportedResponseTypeException;
 use EzSystems\RecommendationBundle\Rest\Field\Value as FieldValue;
 use EzSystems\RecommendationBundle\Rest\Values\ContentData as ContentDataValue;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface as UrlGenerator;
@@ -49,6 +50,9 @@ class ContentController extends BaseController
 
     /** @var \eZ\Publish\Core\MVC\Symfony\SiteAccess */
     protected $siteAccess;
+
+    /** @var int */
+    protected $customerId;
 
     /** @var int $defaultAuthorId */
     protected $defaultAuthorId;
@@ -92,18 +96,34 @@ class ContentController extends BaseController
     }
 
     /**
+     * Sets `customerId` option when service is created which allows to
+     * inject parameter value according to siteaccess configuration.
+     *
+     * @param string $value
+     */
+    public function setCustomerId($value)
+    {
+        $this->customerId = $value;
+    }
+
+    /**
      * Prepares content for ContentDataValue class.
      *
      * @param string $contentIdList
+     * @param string $responseType
      * @param \Symfony\Component\HttpFoundation\Request $request
      *
      * @return \EzSystems\RecommendationBundle\Rest\Values\ContentData
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if the content, version with the given id and languages or content type does not exist
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException If the user has no access to read content and in case of un-published content: read versions
+     * @throws \EzSystems\RecommendationBundle\Rest\Exception\UnsupportedResponseTypeException
      */
-    public function getContent($contentIdList, Request $request)
+    public function getContent($contentIdList, $responseType, Request $request)
     {
+        if ($responseType != 'http') {
+            throw new UnsupportedResponseTypeException('Only http response is available for single content');
+        }
         $contentIds = explode(',', $contentIdList);
         $lang = $request->get('lang');
 
@@ -122,9 +142,14 @@ class ContentController extends BaseController
 
         $contentItems = $this->searchService->findContent($query)->searchHits;
 
-        $data = $this->prepareContent($contentItems, $request);
+        $content = $this->prepareContent($contentItems, $request);
 
-        return new ContentDataValue($data);
+        return new ContentDataValue($content, [
+            'responseType' => 'http',
+            'documentRoot' => $request->server->get('DOCUMENT_ROOT'),
+            'host' => $request->getSchemeAndHttpHost(),
+            'customerId' => $this->customerId,
+        ]);
     }
 
     /**

--- a/Rest/Controller/ExportController.php
+++ b/Rest/Controller/ExportController.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * This file is part of the EzSystemRecommendationBundle package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RecommendationBundle\Rest\Controller;
+
+use eZ\Publish\Core\REST\Common\Exceptions\NotFoundException;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\ServerBag;
+use Symfony\Component\HttpKernel\Kernel;
+
+class ExportController extends Controller
+{
+    /** @var \Symfony\Component\HttpKernel\Kernel */
+    private $kernel;
+
+    /**
+     * @param \Symfony\Component\HttpKernel\Kernel $kernel
+     */
+    public function __construct(Kernel $kernel)
+    {
+        $this->kernel = $kernel;
+    }
+
+    /**
+     * @param string $filePath
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     *
+     * @return \Symfony\Component\HttpFoundation\Response
+     *
+     * @throws \Symfony\Component\HttpFoundation\File\Exception\AccessDeniedException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     */
+    public function downloadAction($filePath, Request $request)
+    {
+        $response = new Response();
+
+        if (!$this->authenticate($filePath, $request->server) || strstr($filePath, '.')) {
+            return $response->setStatusCode(401);
+        }
+
+        $path = $this->kernel->getRootDir() . '/../web/var/export/';
+
+        if (!file_exists($path . $filePath)) {
+            throw new NotFoundException('File not found.');
+        }
+
+        $content = file_get_contents($path . $filePath);
+
+        $response->headers->set('Content-Type', 'mime/type');
+        $response->headers->set('Content-Disposition', 'attachment;filename="' . $filePath);
+
+        $response->setContent($content);
+
+        return $response;
+    }
+
+    /**
+     * @param string $filePath
+     * @param \Symfony\Component\HttpFoundation\ServerBag $server
+     *
+     * @return bool
+     */
+    private function authenticate($filePath, ServerBag $server)
+    {
+        $passFile = $this->kernel->getRootDir() . '/../web/var/export/'
+            . substr($filePath, 0, strrpos($filePath, '/'))
+            . '/.htpasswd';
+
+        list($auth['user'], $auth['pass']) = explode(':', file_get_contents($passFile));
+        $user = $server->get('PHP_AUTH_USER');
+        $pass = crypt($server->get('PHP_AUTH_PW'), md5($server->get('PHP_AUTH_PW')));
+
+        return ($user == $auth['user'] && $pass == $auth['pass']);
+    }
+}

--- a/Rest/Exception/ExportInProgressException.php
+++ b/Rest/Exception/ExportInProgressException.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * This file is part of the EzSystemRecommendationBundle package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RecommendationBundle\Rest\Exception;
+
+class ExportInProgressException extends \Exception
+{
+}

--- a/Rest/Exception/ResponseClassNotImplementedException.php
+++ b/Rest/Exception/ResponseClassNotImplementedException.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * This file is part of the EzSystemRecommendationBundle package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RecommendationBundle\Rest\Exception;
+
+class ResponseClassNotImplementedException extends \Exception
+{
+}

--- a/Rest/Exception/UnsupportedResponseTypeException.php
+++ b/Rest/Exception/UnsupportedResponseTypeException.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * This file is part of the EzSystemRecommendationBundle package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RecommendationBundle\Rest\Exception;
+
+class UnsupportedResponseTypeException extends \Exception
+{
+}

--- a/Rest/Field/RelationMapper.php
+++ b/Rest/Field/RelationMapper.php
@@ -11,7 +11,7 @@ class RelationMapper
     protected $fieldMappings;
 
     /**
-     * @param array $fieldMapping
+     * @param array $fieldMappings
      */
     public function __construct(array $fieldMappings)
     {

--- a/Rest/Response/ExportResponse.php
+++ b/Rest/Response/ExportResponse.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * This file is part of the EzSystemRecommendationBundle package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RecommendationBundle\Rest\Response;
+
+use eZ\Publish\Core\REST\Common\Output\Generator;
+use EzSystems\RecommendationBundle\Rest\Exception\ExportInProgressException;
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Request;
+
+class ExportResponse extends Response
+{
+    /** @var string */
+    private $apiEndpoint;
+
+    /**
+     * @param string $apiEndpoint
+     */
+    public function setApiEndpoint($apiEndpoint)
+    {
+        $this->apiEndpoint = $apiEndpoint;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function render(Generator $generator, $data)
+    {
+        ini_set('max_execution_time', 0);
+        if (file_exists($data->options['documentRoot'] . '/var/export/.lock')) {
+            throw new ExportInProgressException('Export is running');
+        }
+
+        $chunkDir = $this->createChunkDir($data->options['documentRoot']);
+        $chunkDirPath = $data->options['documentRoot'] . '/var/export' . $chunkDir;
+        $chunks = array_chunk($data->contents, $data->options['chunkSize']);
+
+        $urls = [];
+        touch($data->options['documentRoot'] . '/var/export/.lock');
+
+        foreach ($chunks as $id => $chunk) {
+            $chunkPath = $chunkDirPath . $id;
+
+            $generator->reset();
+            $generator->startDocument($chunk);
+
+            $this->contentListElementGenerator->generateElement($generator, $chunk);
+
+            file_put_contents($chunkPath, $generator->endDocument($chunk));
+
+            $urls[] = sprintf('%s/api/ezp/v2/ez_recommendation/v1/exportDownload%s%s', $data->options['host'], $chunkDir, $id);
+        }
+
+        unlink($data->options['documentRoot'] . '/var/export/.lock');
+
+        echo $this->sendYCResponse($urls, $data->options['customerId'], $chunkDirPath);
+
+        $generator->reset();
+
+        return $generator;
+    }
+
+    /**
+     * @param $documentRoot
+     *
+     * @return false|string
+     */
+    private function createChunkDir($documentRoot)
+    {
+        $chunkDir = date('/Y/m/d/H/i/', time());
+
+        $dir = $documentRoot . '/var/export' . $chunkDir;
+        if (!file_exists($dir)) {
+            mkdir($dir, 0777, true);
+        }
+
+        return $chunkDir;
+    }
+
+    /**
+     * @param $urls
+     * @param $customerId
+     * @param $chunkDirPath
+     *
+     * @return \Psr\Http\Message\StreamInterface|string
+     */
+    private function sendYCResponse($urls, $customerId, $chunkDirPath)
+    {
+        $guzzle = new Client([
+            'base_uri' => $this->apiEndpoint . '/api/',
+        ]);
+
+        try {
+            $response = $guzzle->send(
+                new Request(
+                    'POST',
+                    sprintf('%s/items', $customerId),
+                    [],
+                    json_encode([
+                        'transaction' => '',
+                        'events' => [
+                            'action' => 'FULL',
+                            'uri' => $urls,
+                            'credentials' => [
+                                'login' => 'yc',
+                                'password' => $this->secureDir($chunkDirPath),
+                            ],
+                        ],
+                    ])
+                )
+            )->getBody();
+        } catch (\Exception $e) {
+            $response = json_encode([
+                $e->getMessage(), $e->getCode(), $e->getFile(), $e->getLine(),
+            ]);
+        }
+
+        return $response;
+    }
+
+    /**
+     * @param string $dir
+     *
+     * @return string
+     */
+    private function secureDir($dir)
+    {
+        $password = substr(md5(microtime()), 0, 10);
+        file_put_contents($dir . '.htpasswd', sprintf('yc:%s', crypt($password, md5($password))));
+
+        return $password;
+    }
+}

--- a/Rest/Response/ExportResponse.php
+++ b/Rest/Response/ExportResponse.php
@@ -11,6 +11,7 @@ use eZ\Publish\Core\REST\Common\Output\Generator;
 use EzSystems\RecommendationBundle\Rest\Exception\ExportInProgressException;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Request;
+use Symfony\Component\HttpFoundation\JsonResponse;
 
 class ExportResponse extends Response
 {
@@ -25,9 +26,6 @@ class ExportResponse extends Response
         $this->apiEndpoint = $apiEndpoint;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function render(Generator $generator, $data)
     {
         ini_set('max_execution_time', 0);
@@ -114,7 +112,7 @@ class ExportResponse extends Response
                 )
             )->getBody();
         } catch (\Exception $e) {
-            $response = json_encode([
+            return new JsonResponse([
                 $e->getMessage(), $e->getCode(), $e->getFile(), $e->getLine(),
             ]);
         }

--- a/Rest/Response/HttpResponse.php
+++ b/Rest/Response/HttpResponse.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * This file is part of the EzSystemRecommendationBundle package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RecommendationBundle\Rest\Response;
+
+use eZ\Publish\Core\REST\Common\Output\Generator;
+
+class HttpResponse extends Response
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function render(Generator $generator, $data)
+    {
+        return $this->contentListElementGenerator->generateElement($generator, $data->contents);
+    }
+}

--- a/Rest/Response/HttpResponse.php
+++ b/Rest/Response/HttpResponse.php
@@ -11,9 +11,6 @@ use eZ\Publish\Core\REST\Common\Output\Generator;
 
 class HttpResponse extends Response
 {
-    /**
-     * {@inheritdoc}
-     */
     public function render(Generator $generator, $data)
     {
         return $this->contentListElementGenerator->generateElement($generator, $data->contents);

--- a/Rest/Response/Response.php
+++ b/Rest/Response/Response.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * This file is part of the EzSystemRecommendationBundle package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RecommendationBundle\Rest\Response;
+
+use EzSystems\RecommendationBundle\Rest\ValueObjectVisitor\ContentListElementGenerator;
+
+abstract class Response implements ResponseInterface
+{
+    /** @var \EzSystems\RecommendationBundle\Rest\ValueObjectVisitor\ContentListElementGenerator */
+    public $contentListElementGenerator;
+
+    /**
+     * @param \EzSystems\RecommendationBundle\Rest\ValueObjectVisitor\ContentListElementGenerator $contentListElementGenerator
+     */
+    public function __construct(ContentListElementGenerator $contentListElementGenerator)
+    {
+        $this->contentListElementGenerator = $contentListElementGenerator;
+    }
+}

--- a/Rest/Response/ResponseInterface.php
+++ b/Rest/Response/ResponseInterface.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * This file is part of the EzSystemRecommendationBundle package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RecommendationBundle\Rest\Response;
+
+use eZ\Publish\Core\REST\Common\Output\Generator;
+
+interface ResponseInterface
+{
+    /**
+     * @param \eZ\Publish\Core\REST\Common\Output\Generator $generator
+     * @param mixed $data
+     */
+    public function render(Generator $generator, $data);
+}

--- a/Rest/ValueObjectVisitor/ContentListElementGenerator.php
+++ b/Rest/ValueObjectVisitor/ContentListElementGenerator.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * This file is part of the EzSystemRecommendationBundle package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RecommendationBundle\Rest\ValueObjectVisitor;
+
+use eZ\Publish\Core\REST\Common\Output\Generator;
+
+class ContentListElementGenerator
+{
+    /**
+     * @param \eZ\Publish\Core\REST\Common\Output\Generator $generator
+     * @param array $contentList
+     *
+     * @return Generator
+     */
+    public function generateElement(Generator $generator, array $contentList = [])
+    {
+        $generator->startObjectElement('contentList');
+        $generator->startList('content');
+
+        foreach ($contentList as $content) {
+            $generator->startObjectElement('content');
+
+            $generator->startValueElement('contentId', $content['contentId']);
+            $generator->endValueElement('contentId');
+
+            $generator->startValueElement('contentTypeId', $content['contentTypeId']);
+            $generator->endValueElement('contentTypeId');
+
+            $generator->startValueElement('identifier', $content['identifier']);
+            $generator->endValueElement('identifier');
+
+            $generator->startValueElement('language', $content['language']);
+            $generator->endValueElement('language');
+
+            $generator->startValueElement('publishedDate', $content['publishedDate']);
+            $generator->endValueElement('publishedDate');
+
+            $generator->startValueElement('author', $content['author']);
+            $generator->endValueElement('author');
+
+            $generator->startValueElement('uri', $content['uri']);
+            $generator->endValueElement('uri');
+
+            $generator->startValueElement('categoryPath', $content['categoryPath']);
+            $generator->endValueElement('categoryPath');
+
+            $generator->startObjectElement('mainLocation');
+            $generator->startAttribute('href', $content['mainLocation']['href']);
+            $generator->endAttribute('href');
+            $generator->endObjectElement('mainLocation');
+
+            $generator->startObjectElement('locations');
+            $generator->startAttribute('href', $content['locations']['href']);
+            $generator->endAttribute('href');
+            $generator->endObjectElement('locations');
+
+            $generator->startList('fields');
+
+            foreach ($content['fields'] as $field) {
+                $generator->startHashElement('fields');
+                $generator->startValueElement('key', $field['key']);
+                $generator->endValueElement('key');
+                $generator->startValueElement('value', $field['value']);
+                $generator->endValueElement('value');
+                $generator->endHashElement('fields');
+            }
+
+            $generator->endList('fields');
+            $generator->endObjectElement('content');
+        }
+
+        $generator->endList('content');
+        $generator->endObjectElement('contentList');
+
+        return $generator;
+    }
+}

--- a/Rest/Values/ContentData.php
+++ b/Rest/Values/ContentData.php
@@ -17,9 +17,11 @@ class ContentData
      * Constructs ContentData object.
      *
      * @param array $contents
+     * @param array $options
      */
-    public function __construct($contents)
+    public function __construct(array $contents, array $options = [])
     {
         $this->contents = $contents;
+        $this->options = $options;
     }
 }


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZS-911

### Usage

Add `/export` after content type list in url for export to files, eg.:
`/api/ezp/v2/ez_recommendation/v1/contenttypes/18,16/export?fields=title,image`

Default page size is set to:
* 10 for regular response
* 1000 for export response

It can be changed by setting `page_size`: `[...]&page_size=120`

`page (offset)` argument is ignored in `export` response

Export finish trigger the POST request to Yoochoose endpoint `/api/{customerId}/items` sending a list of urls for downloading the content files and credentials necessary for authorization. That request is also a response displayed after export finish.