### PR TITLE
EZP-28161: Update php-cs-fixer configuration to align with v2.7.1

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -16,6 +16,8 @@ return PhpCsFixer\Config::create()
         'phpdoc_annotation_without_dot' => false,
         'phpdoc_no_alias_tag' => false,
         'space_after_semicolon' => false,
+        'yoda_style' => false,
+        'no_break_comment' => false,
     ])
     ->setRiskyAllowed(true)
     ->setFinder(

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ before_script:
   - echo 'memory_limit = -1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   # If set update symfony version
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/symfony=$SYMFONY_VERSION; fi;
+  # Remove php-cs-fixer as it is currently not needed on Travis
+  - composer remove --dev --no-update friendsofphp/php-cs-fixer
   # Install packages using composer
   - composer install --prefer-dist
   # Detecting timezone issues by testing on random timezone

--- a/Tests/Client/YooChooseNotifierTest.php
+++ b/Tests/Client/YooChooseNotifierTest.php
@@ -8,7 +8,6 @@ namespace EzSystems\RecommendationBundle\Tests\Client;
 use PHPUnit_Framework_TestCase;
 use GuzzleHttp\Promise\Promise;
 use GuzzleHttp\Psr7\Response;
-use eZ\Publish\Core\Repository\Values\Content\Content;
 use eZ\Publish\Core\Repository\Values\ContentType\ContentType;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use EzSystems\RecommendationBundle\Client\YooChooseNotifier;
@@ -250,14 +249,10 @@ class YooChooseNotifierTest extends PHPUnit_Framework_TestCase
      */
     protected function getRepositoryServiceMock($identifier)
     {
-        $repositoryInterfaceServiceMock = $this->getMock('eZ\Publish\API\Repository\Repository');
-        $signalDispatcherServiceMock = $this->getMock('eZ\Publish\Core\SignalSlot\SignalDispatcher');
-
-        $repositoryServiceMock = $this->getMock(
-            'eZ\Publish\Core\SignalSlot\Repository',
-            array('sudo', 'getContentService', 'getContentTypeService'),
-            array($repositoryInterfaceServiceMock, $signalDispatcherServiceMock)
-        );
+        $repositoryServiceMock = $this
+            ->getMockBuilder('\eZ\Publish\Core\SignalSlot\Repository')
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $repositoryServiceMock
             ->expects($this->any())

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "ezsystems/ezpublish-kernel": "~5.1 || ^6.7",
         "guzzlehttp/guzzle": "~5.0|~6.0",
         "components/handlebars.js": "~3.0.0",
-        "symfony/symfony": "^2.7.7"
+        "symfony/symfony": "^2.7.7 || ^3.3"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.7",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~4.7",
-        "friendsofphp/php-cs-fixer": "^2.1"
+        "friendsofphp/php-cs-fixer": "~2.7.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,12 @@
         }
     ],
     "require": {
+        "ezsystems/ezpublish-kernel": "~5.1 || ^6.7",
         "guzzlehttp/guzzle": "~5.0|~6.0",
         "components/handlebars.js": "~3.0.0",
         "symfony/symfony": "^2.7.7"
     },
     "require-dev": {
-        "ezsystems/ezpublish-kernel": "~6.0.0 | ~5.1",
         "phpunit/phpunit": "~4.7",
         "friendsofphp/php-cs-fixer": "^2.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,9 @@
             "EzSystems\\RecommendationBundle\\": ""
         }
     },
+    "scripts": {
+        "fix-cs": "@php ./vendor/bin/php-cs-fixer fix -v --show-progress=estimating"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "1.2.x-dev"


### PR DESCRIPTION
# Fixes [EZP-28161](https://jira.ez.no/browse/EZP-28161) (1.2 backport)

This PR updates `.php_cs` config and adds composer command `fix-cs`:
```
composer fix-cs
```
to simplify fixing CS.

**TODO**:
- [x] Get feedback on composer changes.
- [x] Update php-cs-fixer config (`.php_cs`)
- [x] Add fix-cs composer command
- [x] Move `ezpublish-kernel` dependency from `require-dev` to `require` and set 6.x to `^6.7`
- [x] Allow Symfony `^3.3`