### PR TITLE
Notifier cleanup

### DIFF
--- a/Client/RecommendationClient.php
+++ b/Client/RecommendationClient.php
@@ -11,8 +11,9 @@ interface RecommendationClient
      * Notifies YooChoose about content update with specified $contentId.
      *
      * @param mixed $contentId
+     * @param mixed $versionId
      */
-    public function updateContent($contentId);
+    public function updateContent($contentId, $versionId = null);
 
     /**
      * Notifies YooChoose about content deletion with specified $contentId.

--- a/eZ/Publish/Slot/CopyContent.php
+++ b/eZ/Publish/Slot/CopyContent.php
@@ -23,6 +23,6 @@ class CopyContent extends Base
             return;
         }
 
-        $this->client->updateContent($signal->dstContentId);
+        $this->client->updateContent($signal->dstContentId, $signal->dstVersionNo);
     }
 }

--- a/eZ/Publish/Slot/DeleteVersion.php
+++ b/eZ/Publish/Slot/DeleteVersion.php
@@ -18,6 +18,6 @@ class DeleteVersion extends Base
             return;
         }
 
-        $this->client->updateContent($signal->contentId);
+        $this->client->updateContent($signal->contentId, $signal->versionNo);
     }
 }

--- a/eZ/Publish/Slot/PublishVersion.php
+++ b/eZ/Publish/Slot/PublishVersion.php
@@ -18,6 +18,6 @@ class PublishVersion extends Base
             return;
         }
 
-        $this->client->updateContent($signal->contentId);
+        $this->client->updateContent($signal->contentId, $signal->versionNo);
     }
 }


### PR DESCRIPTION
Notifier cleanup for export feature (will be added as separate PR)
Changes have been extracted from https://github.com/ezsystems/EzSystemsRecommendationBundle/pull/94

- [x] improved Client/YooChooseNotifier for testing purposes
- [x] added tests for YoochooseNotifier: HideLocation, HideLocationWithChildren, UnhideLocation, UnhideLocationWithChildren
- [x] improved tests and assertions
- [x] removed asynchronous call for guzzle6

https://jira.ez.no/browse/EZEE-1272
https://jira.ez.no/browse/EZEE-1785