### PR TITLE
EZEE-1784: Update reverse relations when content object is published

### DIFF
--- a/Resources/config/slots.yml
+++ b/Resources/config/slots.yml
@@ -30,7 +30,7 @@ services:
             - "@ezpublish.api.persistence_handler"
 
     ez_recommendation.ez_slot.publish_version:
-        parent: ez_recommendation.ez_slot.base
+        parent: ez_recommendation.ez_slot.persistence_aware_base
         class: "%ez_recommendation.ez_slot.publish_version.class%"
         tags:
             - {name: ezpublish.api.slot, signal: ContentService\PublishVersionSignal}

--- a/Resources/config/slots.yml
+++ b/Resources/config/slots.yml
@@ -78,7 +78,7 @@ services:
             - {name: ezpublish.api.slot, signal: LocationService\MoveSubtreeSignal}
 
     ez_recommendation.ez_slot.trash:
-        parent: ez_recommendation.ez_slot.base
+        parent: ez_recommendation.ez_slot.persistence_aware_base
         class: "%ez_recommendation.ez_slot.trash.class%"
         tags:
             - {name: ezpublish.api.slot, signal: TrashService\TrashSignal}

--- a/Tests/eZ/Publish/Slot/AbstractPersistenceAwareBaseTest.php
+++ b/Tests/eZ/Publish/Slot/AbstractPersistenceAwareBaseTest.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RecommendationBundle\Tests\eZ\Publish\Slot;
+
+abstract class AbstractPersistenceAwareBaseTest extends AbstractSlotTest
+{
+    /** @var \eZ\Publish\SPI\Persistence\Handler|\PHPUnit_Framework_MockObject_MockObject */
+    protected $persistenceHandler;
+
+    public function setUp()
+    {
+        $this->persistenceHandler = $this->getMock('\eZ\Publish\SPI\Persistence\Handler');
+
+        parent::setUp();
+    }
+
+    protected function createSlot()
+    {
+        $class = $this->getSlotClass();
+
+        return new $class($this->client, $this->persistenceHandler);
+    }
+}

--- a/Tests/eZ/Publish/Slot/AbstractSlotTest.php
+++ b/Tests/eZ/Publish/Slot/AbstractSlotTest.php
@@ -1,0 +1,228 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RecommendationBundle\Tests\eZ\Publish\Slot;
+
+use PHPUnit\Framework\TestCase;
+
+abstract class AbstractSlotTest extends TestCase
+{
+    /** @var \EzSystems\RecommendationBundle\Client\RecommendationClient|\PHPUnit_Framework_MockObject_MockObject */
+    protected $client;
+
+    /** @var \EzSystems\RecommendationBundle\eZ\Publish\Slot\Base */
+    protected $slot;
+
+    public function setUp()
+    {
+        $this->client = $this->getMock('\EzSystems\RecommendationBundle\Client\RecommendationClient');
+        $this->slot = $this->createSlot();
+    }
+
+    public function testReceiveSignal()
+    {
+        $this->client->expects($this->never())->method('updateContent');
+        $this->client->expects($this->never())->method('deleteContent');
+        $this->client->expects($this->never())->method('hideLocation');
+        $this->client->expects($this->never())->method('unhideLocation');
+
+        $this->slot->receive($this->createSignal());
+    }
+
+    /**
+     * @dataProvider getUnreceivedSignals
+     */
+    public function testDoesNotReceiveOtherSignals($signal)
+    {
+        $this->client->expects($this->never())->method('updateContent');
+        $this->client->expects($this->never())->method('deleteContent');
+        $this->client->expects($this->never())->method('hideLocation');
+        $this->client->expects($this->never())->method('unhideLocation');
+
+        $this->slot->receive($signal);
+    }
+
+    public function getReceivedSignals()
+    {
+        return [
+            $this->createSignal(),
+        ];
+    }
+
+    public function getUnreceivedSignals()
+    {
+        $arguments = [];
+
+        $signals = $this->getAllSignals();
+        foreach ($signals as $signalClass) {
+            if (in_array($signalClass, $this->getReceivedSignalClasses())) {
+                continue;
+            }
+            $arguments[] = [new $signalClass()];
+        }
+
+        return $arguments;
+    }
+
+    /**
+     * Asserts that recommendation service is notified about update of specified content objects.
+     *
+     * @param array $notifications
+     */
+    protected function assertRecommendationServiceIsNotified(array $notifications)
+    {
+        $notifications = array_merge([
+            'deleteContent' => [],
+            'updateContent' => [],
+            'hideLocation' => [],
+            'unhideLocation' => [],
+        ], $notifications);
+
+        foreach ($notifications as $action => $contentIds) {
+            if (empty($contentIds)) {
+                $this->client->expects($this->never())->method($action);
+            } else {
+                $this->client
+                    ->expects($this->exactly(count($contentIds)))
+                    ->method($action)
+                    ->willReturnCallback(function ($id) use ($contentIds) {
+                        $this->assertContains($id, $contentIds);
+                    });
+            }
+        }
+    }
+
+    /**
+     * Asserts that recommendation service is notified about delete of specified content objects.
+     *
+     * @param array $contentIds
+     */
+    protected function assertContentIsDeleted(array $contentIds)
+    {
+        $this->client
+            ->expects($this->exactly(count($contentIds)))
+            ->method('deleteContent')
+            ->willReturnCallback(function ($id) use ($contentIds) {
+                $this->assertContains($id, $contentIds);
+            });
+    }
+
+    /**
+     * Asserts that recommendation service is notified about update of specified content objects.
+     *
+     * @param array $contentIds
+     */
+    protected function assertContentIsUpdated(array $contentIds)
+    {
+        $this->client
+            ->expects($this->exactly(count($contentIds)))
+            ->method('updateContent')
+            ->willReturnCallback(function ($id) use ($contentIds) {
+                $this->assertContains($id, $contentIds);
+            });
+    }
+
+    protected function createSlot()
+    {
+        $class = $this->getSlotClass();
+
+        return new $class($this->client);
+    }
+
+    abstract protected function createSignal();
+
+    abstract protected function getSlotClass();
+
+    abstract protected function getReceivedSignalClasses();
+
+    /**
+     * @return array
+     */
+    private function getAllSignals()
+    {
+        return [
+            'eZ\Publish\Core\SignalSlot\Signal\URLAliasService\CreateUrlAliasSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\URLAliasService\RemoveAliasesSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\URLAliasService\CreateGlobalUrlAliasSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\CreateContentTypeSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\AddFieldDefinitionSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\CopyContentTypeSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\DeleteContentTypeSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\UpdateContentTypeGroupSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\DeleteContentTypeGroupSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\UnassignContentTypeGroupSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\PublishContentTypeDraftSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\AssignContentTypeGroupSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\UpdateFieldDefinitionSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\UpdateContentTypeDraftSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\RemoveFieldDefinitionSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\CreateContentTypeDraftSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\CreateContentTypeGroupSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\LanguageService\EnableLanguageSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\LanguageService\UpdateLanguageNameSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\LanguageService\CreateLanguageSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\LanguageService\DisableLanguageSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\LanguageService\DeleteLanguageSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\UserService\MoveUserGroupSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\UserService\DeleteUserGroupSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\UserService\CreateUserGroupSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\UserService\UpdateUserGroupSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\UserService\UnAssignUserFromUserGroupSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\UserService\AssignUserToUserGroupSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\UserService\DeleteUserSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\UserService\CreateUserSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\UserService\UpdateUserSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\SectionService\DeleteSectionSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\SectionService\CreateSectionSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\SectionService\UpdateSectionSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\SectionService\AssignSectionSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\RoleService\AssignRoleToUserGroupSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\RoleService\UpdatePolicySignal',
+            'eZ\Publish\Core\SignalSlot\Signal\RoleService\CreateRoleSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\RoleService\RemovePolicySignal',
+            'eZ\Publish\Core\SignalSlot\Signal\RoleService\UnassignRoleFromUserSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\RoleService\AddPolicySignal',
+            'eZ\Publish\Core\SignalSlot\Signal\RoleService\UnassignRoleFromUserGroupSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\RoleService\UpdateRoleSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\RoleService\AssignRoleToUserSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\RoleService\DeleteRoleSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\TrashService\TrashSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\TrashService\EmptyTrashSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\TrashService\RecoverSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\TrashService\DeleteTrashItemSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ObjectStateService\DeleteObjectStateSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ObjectStateService\CreateObjectStateSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ObjectStateService\DeleteObjectStateGroupSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ObjectStateService\CreateObjectStateGroupSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ObjectStateService\UpdateObjectStateSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ObjectStateService\UpdateObjectStateGroupSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ObjectStateService\SetContentStateSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ObjectStateService\SetPriorityOfObjectStateSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\URLWildcardService\TranslateSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\URLWildcardService\RemoveSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\URLWildcardService\CreateSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentService\UpdateContentSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentService\CreateContentDraftSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentService\AddRelationSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentService\CreateContentSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentService\DeleteContentSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentService\AddTranslationInfoSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentService\CopyContentSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentService\UpdateContentMetadataSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentService\TranslateVersionSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentService\PublishVersionSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentService\DeleteRelationSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\ContentService\DeleteVersionSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\LocationService\UpdateLocationSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\LocationService\HideLocationSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\LocationService\SwapLocationSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\LocationService\MoveSubtreeSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\LocationService\UnhideLocationSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\LocationService\CreateLocationSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\LocationService\DeleteLocationSignal',
+            'eZ\Publish\Core\SignalSlot\Signal\LocationService\CopySubtreeSignal',
+        ];
+    }
+}

--- a/Tests/eZ/Publish/Slot/CopyContentTest.php
+++ b/Tests/eZ/Publish/Slot/CopyContentTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RecommendationBundle\Tests\eZ\Publish\Slot;
+
+use eZ\Publish\Core\SignalSlot\Signal\ContentService\CopyContentSignal;
+
+class CopyContentTest extends AbstractSlotTest
+{
+    const DST_CONTENT_ID = 100;
+
+    public function testReceiveSignal()
+    {
+        $this->assertRecommendationServiceIsNotified([
+            'updateContent' => [self::DST_CONTENT_ID],
+        ]);
+
+        $this->slot->receive($this->createSignal());
+    }
+
+    protected function createSignal()
+    {
+        return new CopyContentSignal([
+            'dstContentId' => self::DST_CONTENT_ID,
+        ]);
+    }
+
+    protected function getSlotClass()
+    {
+        return 'EzSystems\RecommendationBundle\eZ\Publish\Slot\CopyContent';
+    }
+
+    protected function getReceivedSignalClasses()
+    {
+        return ['eZ\Publish\Core\SignalSlot\Signal\ContentService\CopyContentSignal'];
+    }
+}

--- a/Tests/eZ/Publish/Slot/CopySubtreeTest.php
+++ b/Tests/eZ/Publish/Slot/CopySubtreeTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RecommendationBundle\Tests\eZ\Publish\Slot;
+
+use eZ\Publish\Core\SignalSlot\Signal\LocationService\CopySubtreeSignal;
+
+class CopySubtreeTest extends AbstractPersistenceAwareBaseTest
+{
+    public function testReceiveSignal()
+    {
+        $signal = $this->createSignal();
+
+        $locationHandler = $this->getMock('\eZ\Publish\SPI\Persistence\Content\Location\Handler');
+        $locationHandler
+            ->expects($this->once())
+            ->method('loadSubtreeIds')
+            ->with($signal->targetNewSubtreeId)
+            ->willReturn($this->getTargetNewSubtreeId());
+
+        $this->persistenceHandler
+            ->expects($this->any())
+            ->method('locationHandler')
+            ->willReturn($locationHandler);
+
+        $this->assertRecommendationServiceIsNotified([
+            'updateContent' => $this->getTargetNewSubtreeId(),
+        ]);
+
+        $this->slot->receive($this->createSignal());
+    }
+
+    protected function createSignal()
+    {
+        return new CopySubtreeSignal([
+            'targetNewSubtreeId' => 100,
+        ]);
+    }
+
+    protected function getSlotClass()
+    {
+        return '\EzSystems\RecommendationBundle\eZ\Publish\Slot\CopySubtree';
+    }
+
+    protected function getReceivedSignalClasses()
+    {
+        return ['eZ\Publish\Core\SignalSlot\Signal\LocationService\CopySubtreeSignal'];
+    }
+
+    private function getTargetNewSubtreeId()
+    {
+        return [2016, 2017, 2018];
+    }
+}

--- a/Tests/eZ/Publish/Slot/CreateLocationTest.php
+++ b/Tests/eZ/Publish/Slot/CreateLocationTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RecommendationBundle\Tests\eZ\Publish\Slot;
+
+use eZ\Publish\Core\SignalSlot\Signal\LocationService\CreateLocationSignal;
+
+class CreateLocationTest extends AbstractSlotTest
+{
+    const CONTENT_ID = 100;
+
+    public function testReceiveSignal()
+    {
+        $signal = $this->createSignal();
+
+        $this->assertRecommendationServiceIsNotified([
+            'updateContent' => [self::CONTENT_ID],
+        ]);
+
+        $this->slot->receive($signal);
+    }
+
+    protected function createSignal()
+    {
+        return new CreateLocationSignal([
+            'contentId' => self::CONTENT_ID,
+        ]);
+    }
+
+    protected function getSlotClass()
+    {
+        return '\EzSystems\RecommendationBundle\eZ\Publish\Slot\CreateLocation';
+    }
+
+    protected function getReceivedSignalClasses()
+    {
+        return ['eZ\Publish\Core\SignalSlot\Signal\LocationService\CreateLocationSignal'];
+    }
+}

--- a/Tests/eZ/Publish/Slot/DeleteContentTest.php
+++ b/Tests/eZ/Publish/Slot/DeleteContentTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RecommendationBundle\Tests\eZ\Publish\Slot;
+
+use eZ\Publish\Core\SignalSlot\Signal\ContentService\DeleteContentSignal;
+
+class DeleteContentTest extends AbstractSlotTest
+{
+    const CONTENT_ID = 100;
+
+    public function testReceiveSignal()
+    {
+        $signal = $this->createSignal();
+
+        $this->assertRecommendationServiceIsNotified([
+            'deleteContent' => [self::CONTENT_ID],
+        ]);
+
+        $this->slot->receive($signal);
+    }
+
+    protected function createSignal()
+    {
+        return new DeleteContentSignal([
+            'contentId' => self::CONTENT_ID,
+        ]);
+    }
+
+    protected function getSlotClass()
+    {
+        return 'EzSystems\RecommendationBundle\eZ\Publish\Slot\DeleteContent';
+    }
+
+    protected function getReceivedSignalClasses()
+    {
+        return ['eZ\Publish\Core\SignalSlot\Signal\ContentService\DeleteContentSignal'];
+    }
+}

--- a/Tests/eZ/Publish/Slot/DeleteLocationTest.php
+++ b/Tests/eZ/Publish/Slot/DeleteLocationTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RecommendationBundle\Tests\eZ\Publish\Slot;
+
+use eZ\Publish\Core\SignalSlot\Signal\LocationService\DeleteLocationSignal;
+
+class DeleteLocationTest extends AbstractSlotTest
+{
+    const CONTENT_ID = 100;
+
+    public function testReceiveSignal()
+    {
+        $signal = $this->createSignal();
+
+        $this->assertRecommendationServiceIsNotified([
+            'deleteContent' => [self::CONTENT_ID],
+        ]);
+
+        $this->slot->receive($signal);
+    }
+
+    protected function createSignal()
+    {
+        return new DeleteLocationSignal([
+            'contentId' => self::CONTENT_ID,
+        ]);
+    }
+
+    protected function getSlotClass()
+    {
+        return 'EzSystems\RecommendationBundle\eZ\Publish\Slot\DeleteLocation';
+    }
+
+    protected function getReceivedSignalClasses()
+    {
+        return ['eZ\Publish\Core\SignalSlot\Signal\LocationService\DeleteLocationSignal'];
+    }
+}

--- a/Tests/eZ/Publish/Slot/DeleteVersionTest.php
+++ b/Tests/eZ/Publish/Slot/DeleteVersionTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RecommendationBundle\Tests\eZ\Publish\Slot;
+
+use eZ\Publish\Core\SignalSlot\Signal\ContentService\DeleteVersionSignal;
+
+class DeleteVersionTest extends AbstractSlotTest
+{
+    const CONTENT_ID = 100;
+
+    public function testReceiveSignal()
+    {
+        $signal = $this->createSignal();
+
+        $this->assertRecommendationServiceIsNotified([
+            'updateContent' => [self::CONTENT_ID],
+        ]);
+
+        $this->slot->receive($signal);
+    }
+
+    protected function createSignal()
+    {
+        return new DeleteVersionSignal([
+            'contentId' => self::CONTENT_ID,
+        ]);
+    }
+
+    protected function getSlotClass()
+    {
+        return 'EzSystems\RecommendationBundle\eZ\Publish\Slot\DeleteVersion';
+    }
+
+    protected function getReceivedSignalClasses()
+    {
+        return ['eZ\Publish\Core\SignalSlot\Signal\ContentService\DeleteVersionSignal'];
+    }
+}

--- a/Tests/eZ/Publish/Slot/HideLocationTest.php
+++ b/Tests/eZ/Publish/Slot/HideLocationTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RecommendationBundle\Tests\eZ\Publish\Slot;
+
+use eZ\Publish\Core\SignalSlot\Signal\LocationService\HideLocationSignal;
+
+class HideLocationTest extends AbstractSlotTest
+{
+    const LOCATION_ID = 100;
+
+    public function testReceiveSignal()
+    {
+        $signal = $this->createSignal();
+
+        $this->assertRecommendationServiceIsNotified([
+            'hideLocation' => [self::LOCATION_ID],
+        ]);
+
+        $this->slot->receive($signal);
+    }
+
+    protected function createSignal()
+    {
+        return new HideLocationSignal([
+            'locationId' => self::LOCATION_ID,
+        ]);
+    }
+
+    protected function getSlotClass()
+    {
+        return 'EzSystems\RecommendationBundle\eZ\Publish\Slot\HideLocation';
+    }
+
+    protected function getReceivedSignalClasses()
+    {
+        return ['eZ\Publish\Core\SignalSlot\Signal\LocationService\HideLocationSignal'];
+    }
+}

--- a/Tests/eZ/Publish/Slot/MoveSubtreeTest.php
+++ b/Tests/eZ/Publish/Slot/MoveSubtreeTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RecommendationBundle\Tests\eZ\Publish\Slot;
+
+use eZ\Publish\Core\SignalSlot\Signal\LocationService\MoveSubtreeSignal;
+
+class MoveSubtreeTest extends AbstractPersistenceAwareBaseTest
+{
+    const LOCATION_ID = 100;
+
+    public function testReceiveSignal()
+    {
+        $signal = $this->createSignal();
+
+        $locationHandler = $this->getMock('\eZ\Publish\SPI\Persistence\Content\Location\Handler');
+        $locationHandler
+            ->expects($this->once())
+            ->method('loadSubtreeIds')
+            ->with($signal->locationId)
+            ->willReturn($this->getSubtreeIds());
+
+        $this->persistenceHandler
+            ->expects($this->any())
+            ->method('locationHandler')
+            ->willReturn($locationHandler);
+
+        $this->assertRecommendationServiceIsNotified([
+            'updateContent' => $this->getSubtreeIds(),
+        ]);
+
+        $this->slot->receive($this->createSignal());
+    }
+
+    protected function createSignal()
+    {
+        return new MoveSubtreeSignal([
+            'locationId' => self::LOCATION_ID,
+        ]);
+    }
+
+    protected function getSlotClass()
+    {
+        return '\EzSystems\RecommendationBundle\eZ\Publish\Slot\MoveSubtree';
+    }
+
+    protected function getReceivedSignalClasses()
+    {
+        return ['eZ\Publish\Core\SignalSlot\Signal\LocationService\MoveSubtreeSignal'];
+    }
+
+    private function getSubtreeIds()
+    {
+        return [2016, 2017, 2018];
+    }
+}

--- a/Tests/eZ/Publish/Slot/PublishVersionTest.php
+++ b/Tests/eZ/Publish/Slot/PublishVersionTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RecommendationBundle\Tests\eZ\Publish\Slot;
+
+use eZ\Publish\Core\SignalSlot\Signal\ContentService\PublishVersionSignal;
+use eZ\Publish\SPI\Persistence\Content\Relation;
+
+class PublishVersionTest extends AbstractPersistenceAwareBaseTest
+{
+    const CONTENT_ID = 100;
+
+    public function testReceiveSignal()
+    {
+        $contentHandler = $this->getMock('\eZ\Publish\SPI\Persistence\Content\Handler');
+        $contentHandler
+            ->expects($this->once())
+            ->method('loadReverseRelations')
+            ->with(self::CONTENT_ID)
+            ->willReturn(array_map(function ($id) {
+                return new Relation([
+                    'destinationContentId' => $id,
+                ]);
+            }, $this->getReverseRelationsIds()));
+
+        $this->persistenceHandler
+            ->expects($this->once())
+            ->method('contentHandler')
+            ->willReturn($contentHandler);
+
+        $this->assertRecommendationServiceIsNotified([
+            'updateContent' => array_merge($this->getReverseRelationsIds(), [
+                self::CONTENT_ID,
+            ]),
+        ]);
+
+        $this->slot->receive($this->createSignal());
+    }
+
+    protected function createSignal()
+    {
+        return new PublishVersionSignal([
+            'contentId' => self::CONTENT_ID,
+        ]);
+    }
+
+    protected function getSlotClass()
+    {
+        return 'EzSystems\RecommendationBundle\eZ\Publish\Slot\PublishVersion';
+    }
+
+    protected function getReceivedSignalClasses()
+    {
+        return ['eZ\Publish\Core\SignalSlot\Signal\ContentService\PublishVersionSignal'];
+    }
+
+    private function getReverseRelationsIds()
+    {
+        return [101, 105, 107];
+    }
+}

--- a/Tests/eZ/Publish/Slot/RecoverTest.php
+++ b/Tests/eZ/Publish/Slot/RecoverTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RecommendationBundle\Tests\eZ\Publish\Slot;
+
+use eZ\Publish\SPI\Persistence\Content\Relation;
+use eZ\Publish\Core\SignalSlot\Signal\TrashService\RecoverSignal;
+
+class RecoverTest extends AbstractPersistenceAwareBaseTest
+{
+    const CONTENT_ID = 100;
+    const LOCATION_ID = 58;
+
+    public function testReceiveSignal()
+    {
+        $signal = $this->createSignal();
+
+        $locationHandler = $this->getMock('\eZ\Publish\SPI\Persistence\Content\Location\Handler');
+        $locationHandler
+            ->expects($this->once())
+            ->method('loadSubtreeIds')
+            ->with($signal->newLocationId)
+            ->willReturn($this->getSubtreeIds());
+
+        $contentHandler = $this->getMock('\eZ\Publish\SPI\Persistence\Content\Handler');
+        $contentHandler
+            ->expects($this->once())
+            ->method('loadReverseRelations')
+            ->with(self::CONTENT_ID)
+            ->willReturn(array_map(function ($id) {
+                return new Relation([
+                    'destinationContentId' => $id,
+                ]);
+            }, $this->getReverseRelationsIds()));
+
+        $this->persistenceHandler
+            ->expects($this->any())
+            ->method('contentHandler')
+            ->willReturn($contentHandler);
+
+        $this->persistenceHandler
+            ->expects($this->any())
+            ->method('locationHandler')
+            ->willReturn($locationHandler);
+
+        $this->assertRecommendationServiceIsNotified([
+            'updateContent' => array_merge($this->getReverseRelationsIds(), $this->getSubtreeIds()),
+        ]);
+
+        $this->slot->receive($signal);
+    }
+
+    protected function createSignal()
+    {
+        return new RecoverSignal([
+            'contentId' => self::CONTENT_ID,
+            'newLocationId' => self::LOCATION_ID,
+        ]);
+    }
+
+    protected function getSlotClass()
+    {
+        return 'EzSystems\RecommendationBundle\eZ\Publish\Slot\Recover';
+    }
+
+    protected function getReceivedSignalClasses()
+    {
+        return ['eZ\Publish\Core\SignalSlot\Signal\TrashService\RecoverSignal'];
+    }
+
+    private function getSubtreeIds()
+    {
+        return [2016, 2017, 2018];
+    }
+
+    private function getReverseRelationsIds()
+    {
+        return [101, 105, 107];
+    }
+}

--- a/Tests/eZ/Publish/Slot/SetContentStateTest.php
+++ b/Tests/eZ/Publish/Slot/SetContentStateTest.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RecommendationBundle\Tests\eZ\Publish\Slot;
+
+use eZ\Publish\Core\SignalSlot\Signal\ObjectStateService\SetContentStateSignal;
+
+class SetContentStateTest extends AbstractSlotTest
+{
+    const CONTENT_ID = 100;
+
+    public function testReceiveSignal()
+    {
+        $signal = $this->createSignal();
+
+        $this->assertRecommendationServiceIsNotified([
+            'updateContent' => [self::CONTENT_ID],
+        ]);
+
+        $this->slot->receive($signal);
+    }
+
+    protected function createSignal()
+    {
+        return new SetContentStateSignal([
+            'contentId' => self::CONTENT_ID,
+        ]);
+    }
+
+    protected function getSlotClass()
+    {
+        return 'EzSystems\RecommendationBundle\eZ\Publish\Slot\SetContentState';
+    }
+
+    protected function getReceivedSignalClasses()
+    {
+        return ['eZ\Publish\Core\SignalSlot\Signal\ObjectStateService\SetContentStateSignal'];
+    }
+}

--- a/Tests/eZ/Publish/Slot/TrashTest.php
+++ b/Tests/eZ/Publish/Slot/TrashTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\RecommendationBundle\Tests\eZ\Publish\Slot;
+
+use eZ\Publish\Core\SignalSlot\Signal\TrashService\TrashSignal;
+use eZ\Publish\SPI\Persistence\Content\Relation;
+
+class TrashTest extends AbstractPersistenceAwareBaseTest
+{
+    const CONTENT_ID = 100;
+
+    public function testReceiveSignal()
+    {
+        $contentHandler = $this->getMock('\eZ\Publish\SPI\Persistence\Content\Handler');
+        $contentHandler
+            ->expects($this->once())
+            ->method('loadReverseRelations')
+            ->with(self::CONTENT_ID)
+            ->willReturn(array_map(function ($id) {
+                return new Relation([
+                    'destinationContentId' => $id,
+                ]);
+            }, $this->getReverseRelationsIds()));
+
+        $this->persistenceHandler
+            ->expects($this->once())
+            ->method('contentHandler')
+            ->willReturn($contentHandler);
+
+        $this->assertRecommendationServiceIsNotified([
+            'deleteContent' => [self::CONTENT_ID],
+            'updateContent' => $this->getReverseRelationsIds(),
+        ]);
+
+        $this->slot->receive($this->createSignal());
+    }
+
+    protected function createSignal()
+    {
+        return new TrashSignal([
+            'contentId' => self::CONTENT_ID,
+        ]);
+    }
+
+    protected function getSlotClass()
+    {
+        return 'EzSystems\RecommendationBundle\eZ\Publish\Slot\Trash';
+    }
+
+    protected function getReceivedSignalClasses()
+    {
+        return ['eZ\Publish\Core\SignalSlot\Signal\TrashService\TrashSignal'];
+    }
+
+    private function getReverseRelationsIds()
+    {
+        return [101, 105, 107];
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "ezsystems/ezpublish-kernel": "~5.1 || ^6.7",
+        "ezsystems/ezpublish-kernel": "^5.4.12 || ~6.0.1.7 || ^6.7 || ^7.0",
         "guzzlehttp/guzzle": "~5.0|~6.0",
         "components/handlebars.js": "~3.0.0",
         "symfony/symfony": "^2.7.7 || ^3.3"

--- a/eZ/Publish/Slot/PublishVersion.php
+++ b/eZ/Publish/Slot/PublishVersion.php
@@ -10,7 +10,7 @@ namespace EzSystems\RecommendationBundle\eZ\Publish\Slot;
 
 use eZ\Publish\Core\SignalSlot\Signal;
 
-class PublishVersion extends Base
+class PublishVersion extends PersistenceAwareBase
 {
     public function receive(Signal $signal)
     {
@@ -18,6 +18,13 @@ class PublishVersion extends Base
             return;
         }
 
+        $relations = $this->persistenceHandler
+            ->contentHandler()
+            ->loadReverseRelations($signal->contentId);
+
         $this->client->updateContent($signal->contentId);
+        foreach ($relations as $relation) {
+            $this->client->updateContent($relation->destinationContentId);
+        }
     }
 }

--- a/eZ/Publish/Slot/Recover.php
+++ b/eZ/Publish/Slot/Recover.php
@@ -18,16 +18,18 @@ class Recover extends PersistenceAwareBase
             return;
         }
 
-        $contentIdArray = $this->persistenceHandler->locationHandler()->loadSubtreeIds($signal->newLocationId);
-        foreach ($contentIdArray as $contentId) {
-            $this->client->updateContent($contentId);
-        }
+        $contentIdArray = $this->persistenceHandler
+            ->locationHandler()
+            ->loadSubtreeIds($signal->newLocationId);
 
         $relations = $this->persistenceHandler
             ->contentHandler()
             ->loadReverseRelations($signal->contentId);
 
-        $this->client->updateContent($signal->contentId);
+        foreach ($contentIdArray as $contentId) {
+            $this->client->updateContent($contentId);
+        }
+
         foreach ($relations as $relation) {
             $this->client->updateContent($relation->destinationContentId);
         }

--- a/eZ/Publish/Slot/Recover.php
+++ b/eZ/Publish/Slot/Recover.php
@@ -22,5 +22,14 @@ class Recover extends PersistenceAwareBase
         foreach ($contentIdArray as $contentId) {
             $this->client->updateContent($contentId);
         }
+
+        $relations = $this->persistenceHandler
+            ->contentHandler()
+            ->loadReverseRelations($signal->contentId);
+
+        $this->client->updateContent($signal->contentId);
+        foreach ($relations as $relation) {
+            $this->client->updateContent($relation->destinationContentId);
+        }
     }
 }

--- a/eZ/Publish/Slot/Trash.php
+++ b/eZ/Publish/Slot/Trash.php
@@ -23,8 +23,6 @@ class Trash extends PersistenceAwareBase
         $relations = $this->persistenceHandler
             ->contentHandler()
             ->loadReverseRelations($signal->contentId);
-
-        $this->client->updateContent($signal->contentId);
         foreach ($relations as $relation) {
             $this->client->updateContent($relation->destinationContentId);
         }

--- a/eZ/Publish/Slot/Trash.php
+++ b/eZ/Publish/Slot/Trash.php
@@ -10,7 +10,7 @@ namespace EzSystems\RecommendationBundle\eZ\Publish\Slot;
 
 use eZ\Publish\Core\SignalSlot\Signal;
 
-class Trash extends Base
+class Trash extends PersistenceAwareBase
 {
     public function receive(Signal $signal)
     {
@@ -19,5 +19,14 @@ class Trash extends Base
         }
 
         $this->client->deleteContent($signal->contentId);
+
+        $relations = $this->persistenceHandler
+            ->contentHandler()
+            ->loadReverseRelations($signal->contentId);
+
+        $this->client->updateContent($signal->contentId);
+        foreach ($relations as $relation) {
+            $this->client->updateContent($relation->destinationContentId);
+        }
     }
 }


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZEE-1784

## Description

This PR adds a missing synchronization of (reverse) related objects, which should be done together with Content Object after its modification.

## TODO

- [X] Sync. related objects when the content object is published
- [X] Sync. related objects when the content object is trashed/restored from trash
- [ ] Investigate others scenarios
- [x] Unit tests
