### PR TITLE
EZEE-1889: SessionBackup Listener returns error when Session object doesn't exist

### DIFF
--- a/EventListener/SessionBackup.php
+++ b/EventListener/SessionBackup.php
@@ -25,7 +25,7 @@ class SessionBackup
     {
         $session = $event->getRequest()->getSession();
 
-        if (!$session->isStarted()) {
+        if ($session === null || !$session->isStarted()) {
             return;
         }
 


### PR DESCRIPTION
JIRA ticket: [EZEE-1889](https://jira.ez.no/browse/EZEE-1889)

Excerpt from the ticket:
> There have been reports of the following errors in the error log coming from the Recommendation Bundle (SessionBackup listener):
`PHP Fatal error: Uncaught exception 'Symfony\\Component\\Debug\\Exception
FatalErrorException' with message 'Error: Call to a member function isStarted() on null' in /xxx/vendor/ezsystems/recommendation-bundle/EventListener/SessionBackup.php:28\nStack trace:\n#0`
It seems that in some circumstances `$request->getSession()` might return null, which causes the issue above. 
