### PR TITLE
EZEE-2196: [LegacyBridge] Cannot instantiate interface ezpSearchEngine error

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -41,8 +41,7 @@ services:
 
 #    ez_recommendation.legacy.search_engine:
 #        class: ezpSearchEngine
-#        factory_class: EzSystems\RecommendationBundle\eZ\Publish\LegacySearch\LegacySearchFactory
-#        factory_method: build
+#        factory: [EzSystems\RecommendationBundle\eZ\Publish\LegacySearch\LegacySearchFactory, build]
 #        arguments: ["@ezpublish_legacy.kernel"]
 #
 #    ez_recommendation.legacy.recommendation_search_engine:


### PR DESCRIPTION
JIRA issue: https://jira.ez.no/browse/EZEE-2169

The issue comes from the usage of deprecated and removed in Symfony 3.0 `factory_class` and `factory_method` DI methods. Ref:
https://api.symfony.com/2.7/Symfony/Component/DependencyInjection/Definition.html#method_setFactoryClass
https://api.symfony.com/2.7/Symfony/Component/DependencyInjection/Definition.html#method_setFactoryMethod

Documentation PR: https://github.com/ezsystems/developer-documentation/pull/324