### PR TITLE
EZEE-2256: [LegacyBridge][eZ Recommendation][WebProfiler] Null is passed to PreBuildKernelWebHandlerEvent instead of valid Request object

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -37,7 +37,8 @@ services:
         arguments:
             - { base_url: "%ez_recommendation.api_endpoint%" }
 
-  # The configured eZ Publish Platform legacy search engine - enable lines below only if you're using legacy bridge.
+  # The configured eZ Platform legacy search engine.
+  # Copy lines below to your app/config/services.yml file and uncomment them only when using Legacy Bridge.
 
 #    ez_recommendation.legacy.search_engine:
 #        class: ezpSearchEngine

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -47,10 +47,10 @@ services:
 #
 #    ez_recommendation.legacy.recommendation_search_engine:
 #        class: EzSystems\RecommendationBundle\eZ\Publish\LegacySearch\RecommendationLegacySearchEngine
+#        lazy: true
 #        arguments:
 #            - "@ez_recommendation.client.yoochoose_notifier"
 #            - "@ez_recommendation.legacy.search_engine"
-#        lazy: true
 #
 #    ez_recommendation.legacy.search_configuration_mapper:
 #        class: EzSystems\RecommendationBundle\eZ\Publish\LegacySearch\ConfigurationMapper

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -49,6 +49,7 @@ services:
 #        arguments:
 #            - "@ez_recommendation.client.yoochoose_notifier"
 #            - "@ez_recommendation.legacy.search_engine"
+#        lazy: true
 #
 #    ez_recommendation.legacy.search_configuration_mapper:
 #        class: EzSystems\RecommendationBundle\eZ\Publish\LegacySearch\ConfigurationMapper


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZEE-2256](https://jira.ez.no/browse/EZEE-2256)
| **Bug**| yes
| **New feature**    | no

- [x] Documentation PR: https://github.com/ezsystems/developer-documentation/pull/362