### PR TITLE
EZEE-2256: Set proper service as lazy

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -47,13 +47,13 @@ services:
 #
 #    ez_recommendation.legacy.recommendation_search_engine:
 #        class: EzSystems\RecommendationBundle\eZ\Publish\LegacySearch\RecommendationLegacySearchEngine
-#        lazy: true
 #        arguments:
 #            - "@ez_recommendation.client.yoochoose_notifier"
 #            - "@ez_recommendation.legacy.search_engine"
 #
 #    ez_recommendation.legacy.search_configuration_mapper:
 #        class: EzSystems\RecommendationBundle\eZ\Publish\LegacySearch\ConfigurationMapper
+#        lazy: true
 #        arguments:
 #            - "@ez_recommendation.legacy.recommendation_search_engine"
 #            - "@ezpublish.siteaccess"


### PR DESCRIPTION
This PR is a followup for https://github.com/ezsystems/EzSystemsRecommendationBundle/pull/113, where incorrect service has been set as `lazy` what was causing an exception when legacy backoffice (shipped with LegacyBridge) was in use. 