### PR TITLE
TypeValue should has dependency to VariationHandler interface, not implementation

### DIFF
--- a/Rest/Field/TypeValue.php
+++ b/Rest/Field/TypeValue.php
@@ -6,7 +6,7 @@
 namespace EzSystems\RecommendationBundle\Rest\Field;
 
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigResolver;
-use eZ\Bundle\EzPublishCoreBundle\Imagine\AliasGenerator as ImageVariationService;
+use eZ\Publish\SPI\Variation\VariationHandler as ImageVariationService;
 use eZ\Publish\Core\MVC\Exception\SourceImageNotFoundException;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\Field;


### PR DESCRIPTION
This PR solves an issue which causes the following error. `TypeValue` had a dependency on `ImageHandler` implementation which has been changed to `PlaceholderAliasGenerator` recently.

> {"ErrorMessage":{"_media-type":"application\/vnd.ez.api.ErrorMessage+json","errorCode":500,"errorMessage":"Internal Server Error","errorDescription":"Type error: Argument 2 passed to EzSystems\\RecommendationBundle\\Rest\\Field\\TypeValue::__construct() must be an instance of eZ\\Bundle\\EzPublishCoreBundle\\Imagine\\AliasGenerator, instance of eZ\\Bundle\\EzPublishCoreBundle\\Imagine\\PlaceholderAliasGenerator given, called in \/var\/www\/ezplatform-ee\/var\/cache\/prod\/ContainerUeyuunf\/getEzRecommendation_Rest_Field_TypeValueService.php on line 8"}}

Since it's a bug and even eZ Platform v2.2 still installs this bundle in version 2.0.x, I think that it should go to 2.0 branch and up. 