### PR TITLE
EZEE-2313: [eZ Reco] Session ID is empty when Symfony AuthenticationGuard is used

### DIFF
--- a/EventListener/Login.php
+++ b/EventListener/Login.php
@@ -83,6 +83,9 @@ class Login
         }
 
         if (!$event->getRequest()->cookies->has('yc-session-id')) {
+            if (!$this->session->isStarted()) {
+                $this->session->start();
+            }
             $event->getRequest()->cookies->set('yc-session-id', $this->session->getId());
         }
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZEE-2313](https://jira.ez.no/browse/EZEE-2313)
| **Bug**| yes
| **New feature**    | no

This PR introduces additional session `isStarted` check which is necessary in case of using Symfony AuthenticationGuard(s).
