### PR TITLE
Removed unnecessary Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,10 @@ cache:
 matrix:
     fast_finish: true
     include:
+        - php: 7.2
+        - php: 7.1
         - php: 7.0
         - php: 5.6
-        - php: 5.5
-        - php: 5.4
-          env: SYMFONY_VERSION="~2.7.0"
 
 # test only master (+ Pull requests)
 branches:

--- a/Tests/eZ/Publish/Slot/AbstractPersistenceAwareBaseTest.php
+++ b/Tests/eZ/Publish/Slot/AbstractPersistenceAwareBaseTest.php
@@ -12,7 +12,7 @@ abstract class AbstractPersistenceAwareBaseTest extends AbstractSlotTest
 
     public function setUp()
     {
-        $this->persistenceHandler = $this->getMock('\eZ\Publish\SPI\Persistence\Handler');
+        $this->persistenceHandler = $this->getMockBuilder('\eZ\Publish\SPI\Persistence\Handler')->getMock();
 
         parent::setUp();
     }

--- a/Tests/eZ/Publish/Slot/AbstractSlotTest.php
+++ b/Tests/eZ/Publish/Slot/AbstractSlotTest.php
@@ -6,9 +6,12 @@
 namespace EzSystems\RecommendationBundle\Tests\eZ\Publish\Slot;
 
 use PHPUnit\Framework\TestCase;
+use eZ\Publish\Core\Base\Tests\PHPUnit5CompatTrait;
 
 abstract class AbstractSlotTest extends TestCase
 {
+    use PHPUnit5CompatTrait;
+
     /** @var \EzSystems\RecommendationBundle\Client\RecommendationClient|\PHPUnit_Framework_MockObject_MockObject */
     protected $client;
 
@@ -17,7 +20,7 @@ abstract class AbstractSlotTest extends TestCase
 
     public function setUp()
     {
-        $this->client = $this->getMock('\EzSystems\RecommendationBundle\Client\RecommendationClient');
+        $this->client = $this->getMockBuilder('\EzSystems\RecommendationBundle\Client\RecommendationClient')->getMock();
         $this->slot = $this->createSlot();
     }
 

--- a/Tests/eZ/Publish/Slot/CopySubtreeTest.php
+++ b/Tests/eZ/Publish/Slot/CopySubtreeTest.php
@@ -14,7 +14,7 @@ class CopySubtreeTest extends AbstractPersistenceAwareBaseTest
     {
         $signal = $this->createSignal();
 
-        $locationHandler = $this->getMock('\eZ\Publish\SPI\Persistence\Content\Location\Handler');
+        $locationHandler = $this->getMockBuilder('\eZ\Publish\SPI\Persistence\Content\Location\Handler')->getMock();
         $locationHandler
             ->expects($this->once())
             ->method('loadSubtreeIds')

--- a/Tests/eZ/Publish/Slot/MoveSubtreeTest.php
+++ b/Tests/eZ/Publish/Slot/MoveSubtreeTest.php
@@ -16,7 +16,7 @@ class MoveSubtreeTest extends AbstractPersistenceAwareBaseTest
     {
         $signal = $this->createSignal();
 
-        $locationHandler = $this->getMock('\eZ\Publish\SPI\Persistence\Content\Location\Handler');
+        $locationHandler = $this->getMockBuilder('\eZ\Publish\SPI\Persistence\Content\Location\Handler')->getMock();
         $locationHandler
             ->expects($this->once())
             ->method('loadSubtreeIds')

--- a/Tests/eZ/Publish/Slot/PublishVersionTest.php
+++ b/Tests/eZ/Publish/Slot/PublishVersionTest.php
@@ -14,7 +14,7 @@ class PublishVersionTest extends AbstractPersistenceAwareBaseTest
 
     public function testReceiveSignal()
     {
-        $contentHandler = $this->getMock('\eZ\Publish\SPI\Persistence\Content\Handler');
+        $contentHandler = $this->getMockBuilder('\eZ\Publish\SPI\Persistence\Content\Handler')->getMock();
         $contentHandler
             ->expects($this->once())
             ->method('loadReverseRelations')

--- a/Tests/eZ/Publish/Slot/RecoverTest.php
+++ b/Tests/eZ/Publish/Slot/RecoverTest.php
@@ -18,14 +18,14 @@ class RecoverTest extends AbstractPersistenceAwareBaseTest
     {
         $signal = $this->createSignal();
 
-        $locationHandler = $this->getMock('\eZ\Publish\SPI\Persistence\Content\Location\Handler');
+        $locationHandler = $this->getMockBuilder('\eZ\Publish\SPI\Persistence\Content\Location\Handler')->getMock();
         $locationHandler
             ->expects($this->once())
             ->method('loadSubtreeIds')
             ->with($signal->newLocationId)
             ->willReturn($this->getSubtreeIds());
 
-        $contentHandler = $this->getMock('\eZ\Publish\SPI\Persistence\Content\Handler');
+        $contentHandler = $this->getMockBuilder('\eZ\Publish\SPI\Persistence\Content\Handler')->getMock();
         $contentHandler
             ->expects($this->once())
             ->method('loadReverseRelations')

--- a/Tests/eZ/Publish/Slot/TrashTest.php
+++ b/Tests/eZ/Publish/Slot/TrashTest.php
@@ -15,7 +15,7 @@ class TrashTest extends AbstractPersistenceAwareBaseTest
 
     public function testReceiveSignal()
     {
-        $contentHandler = $this->getMock('\eZ\Publish\SPI\Persistence\Content\Handler');
+        $contentHandler = $this->getMockBuilder('\eZ\Publish\SPI\Persistence\Content\Handler')->getMock();
         $contentHandler
             ->expects($this->once())
             ->method('loadReverseRelations')

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "symfony/symfony": "^2.7.7 || ^3.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.7",
+        "phpunit/phpunit": "~4.7 || ^5.7",
         "friendsofphp/php-cs-fixer": "~2.7.1"
     },
     "autoload": {


### PR DESCRIPTION
This PR removes old, unnecessary builds for PHP 5.4 & 5.5. 
Builds both for PHP 5.4 & PHP 5.5 tried to run tests using `ezsystems/ezpublish-kernel` 5.2.0.
Added builds for PHP 7.1 and PHP 7.2 instead. 

This PR is targeted to `2.2` since I want to unblock in my second PR (https://github.com/ezsystems/EzSystemsRecommendationBundle/pull/116), but target branch can be easily changed to master.

You can see example previous failing build here: https://travis-ci.org/ezsystems/EzSystemsRecommendationBundle/builds/425723882

@andrerom / @damianz5 can we drop support for kernel 5.x for `2.2` and up? It will be harder and harder to maintain the bundle which has to support such a wide range of eZ Publish / Platform versions. 