### PR TITLE
Removed PHPUnit5CompatTrait usage from tests

### DIFF
--- a/Tests/eZ/Publish/Slot/AbstractSlotTest.php
+++ b/Tests/eZ/Publish/Slot/AbstractSlotTest.php
@@ -6,7 +6,6 @@
 namespace EzSystems\RecommendationBundle\Tests\eZ\Publish\Slot;
 
 use PHPUnit\Framework\TestCase;
-use eZ\Publish\Core\Base\Tests\PHPUnit5CompatTrait;
 
 abstract class AbstractSlotTest extends TestCase
 {

--- a/Tests/eZ/Publish/Slot/AbstractSlotTest.php
+++ b/Tests/eZ/Publish/Slot/AbstractSlotTest.php
@@ -10,8 +10,6 @@ use eZ\Publish\Core\Base\Tests\PHPUnit5CompatTrait;
 
 abstract class AbstractSlotTest extends TestCase
 {
-    use PHPUnit5CompatTrait;
-
     /** @var \EzSystems\RecommendationBundle\Client\RecommendationClient|\PHPUnit_Framework_MockObject_MockObject */
     protected $client;
 


### PR DESCRIPTION
This PR removes usage of `PHPUnit5CompatTrait` since it is no longer available due to the kernel changes: https://github.com/ezsystems/ezpublish-kernel/pull/2446. 